### PR TITLE
README: update tpm2_startup command tcti options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,7 @@ If you see "ATTESTATION SUCCESSFUL" you're done. Congratz :-D
 
 2. Send TPM startup command:
 
-        /usr/bin/env TPM2TOOLS_TCTI_NAME=socket \
-                TPM2TOOLS_SOCKET_ADDRESS=127.0.0.1 \
-                TPM2TOOLS_SOCKET_PORT=2321 \
-                /usr/local/bin/tpm2_startup --clear
+                /usr/local/bin/tpm2_startup -Tmssim --clear
 
 3. Run Attester and Verifier:
 


### PR DESCRIPTION
Rather than use the environment variables which are not stable between
3.X and 4.X releases, use the -T tcti variable and the "mssim" or socket
designator. Since the simulator was started with defaults, their is no
need to set port or ip.

Fixes: #1

Signed-off-by: William Roberts <william.c.roberts@intel.com>