### PR TITLE
Makefile: Fix undefined reference problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ all.static: $(TARGETS)
 
 
 $(BINDIR)/attester: $(SRCDIR)/attester.c $(OBJECTS)
-	$(CC) $^ $(CFLAGS) $(INCLUDE) $(LIBINCLUDE) $(LDPATH) $(LDFLAGS) -g -o $@ -Wl,--gc-sections
+	$(CC) $^ $(CFLAGS) $(INCLUDE) $(LIBINCLUDE) $(LDPATH) $(LDFLAGS) -g -o $@ -Wl,--gc-sections -lm
 	###strip --strip-unneeded $@
 
 $(BINDIR)/verifier: $(SRCDIR)/verifier.c $(OBJECTS)
-	$(CC) $^ $(CFLAGS) $(INCLUDE) $(LIBINCLUDE) $(LDPATH) $(LDFLAGS) -g -o $@ -Wl,--gc-sections
+	$(CC) $^ $(CFLAGS) $(INCLUDE) $(LIBINCLUDE) $(LDPATH) $(LDFLAGS) -g -o $@ -Wl,--gc-sections -lm
 	###strip --strip-unneeded $@
 
 


### PR DESCRIPTION
CHARRA compilation inside the container ends with undefined
reference error. More details in the issue:
https://github.com/Fraunhofer-SIT/charra/issues/13

Linking the math library `-lm` solved the problem.

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>