### PR TITLE
Using the attester and verifier on two different devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,58 @@ If you see "ATTESTATION SUCCESSFUL" you're done. Congratz :-D
       sleep 1 ; \
       pkill bin/attester
 
+## Remote attestation
 
+You can use attester and verifier on two different devices. To do that,
+you have to provide an external network for the attester container.
+
+1. Create [macvlan network](https://docs.docker.com/network/macvlan/)
+for attester docker container (check your gateway address and replace `x` with
+the correct number):
+
+```
+$ docker network create -d macvlan \
+  --subnet=192.168.x.0/24 \
+  --gateway=192.168.x.1 \
+  -o parent=eth0 pub_net
+```
+
+2. Add `--network` parameter to the `docker run` command in the [run.sh](https://github.com/Fraunhofer-SIT/charra/blob/master/docker/run.sh#L65)
+on the attester device:
+
+```
+## run (transient) Docker container
+/usr/bin/docker run --rm -it \
+	-v "${PWD}/:/home/bob/charra" \
+	--network=pub_net \
+	"${docker_image_fullname}" \
+	"$@"
+```
+
+3. Run the attester docker container and check the IP address.
+
+4. Put the attester address to the `DST_HOST` in the
+[verifier.c](https://github.com/Fraunhofer-SIT/charra/blob/master/src/verifier.c#L51)
+on the verifier device. Rebuild verifier script in the verifier docker
+container:
+
+```
+$ cd charra
+$ make -j
+```
+
+5.  Go to `charra` directory and run attester binary in the attester docker
+container:
+
+```
+$ cd charra
+$ ./bin/attester
+```
+
+6. Run the verifier binary in the verifier docker container:
+
+```
+$ ./bin/verifier
+```
+
+If you see "ATTESTATION SUCCESSFUL" you're done. Congratz :-D

--- a/src/attester.c
+++ b/src/attester.c
@@ -47,9 +47,9 @@
 // #define LOG_LEVEL_CHARRA CHARRA_LOG_DEBUG
 
 /* config */
-static const unsigned int PORT = 5683;	 // default port
+static const unsigned int PORT = 5683;	   // default port
 static const unsigned int MAX_SIZE = 1300; // MTU payload max size
-#define CBOR_ENCODER_BUFFER_LENGTH 20480 // 20 KiB should be sufficient
+#define CBOR_ENCODER_BUFFER_LENGTH 20480   // 20 KiB should be sufficient
 
 /* --- resource handler forward declarations ------------------------------ */
 
@@ -190,8 +190,8 @@ static void coap_attestation_handler(struct coap_context_t* ctx UNUSED,
 	/* load TPM key */
 	charra_log_info("[" LOG_NAME "] Loading TPM key.");
 	if ((charra_r = charra_load_tpm2_key(esys_ctx, req.sig_key_id_len,
-			 req.sig_key_id, &sig_key_handle,
-			 &public_key)) != CHARRA_RC_SUCCESS) {
+			 req.sig_key_id, &sig_key_handle, &public_key)) !=
+		CHARRA_RC_SUCCESS) {
 		charra_log_error("[" LOG_NAME "] Could not load TPM key.");
 		goto error;
 	}
@@ -216,8 +216,8 @@ static void coap_attestation_handler(struct coap_context_t* ctx UNUSED,
 		.attestation_data_len = attest_buf->size,
 		.attestation_data = {0}, // must be memcpy'd, see below
 		.tpm2_signature_len = sizeof(*signature),
-		.tpm2_signature = {0}
-		.tpm2_public_key_len = sizeof(*public_key);
+		.tpm2_signature = {0}, // must be memcpy'd, see below
+		.tpm2_public_key_len = sizeof(*public_key),
 		.tpm2_public_key = {0}}; // must be memcpy'd, see below
 	memcpy(res.attestation_data, attest_buf->attestationData,
 		res.attestation_data_len);

--- a/src/core/charra_dto.h
+++ b/src/core/charra_dto.h
@@ -90,7 +90,7 @@ typedef struct {
 	uint32_t tpm2_signature_len;
 	uint8_t tpm2_signature[sizeof(TPMT_SIGNATURE)];
 	uint32_t tpm2_public_key_len;
-	TPM2B_PUBLIC* tpm2_public_key;
+	uint8_t tpm2_public_key[sizeof(TPM2B_PUBLIC)];
 } msg_attestation_response_dto;
 
 #endif /* CHARRA_DTO_H */

--- a/src/core/charra_dto.h
+++ b/src/core/charra_dto.h
@@ -89,6 +89,8 @@ typedef struct {
 	uint8_t attestation_data[sizeof(TPMS_ATTEST)];
 	uint32_t tpm2_signature_len;
 	uint8_t tpm2_signature[sizeof(TPMT_SIGNATURE)];
+	uint32_t tpm2_public_key_len;
+	TPM2B_PUBLIC* tpm2_public_key;
 } msg_attestation_response_dto;
 
 #endif /* CHARRA_DTO_H */

--- a/src/core/charra_key_mgr.c
+++ b/src/core/charra_key_mgr.c
@@ -51,7 +51,7 @@ CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
 	TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle) {
 	TSS2_RC r = TSS2_RC_SUCCESS;
 	if (external_public_key == NULL){
-		charra_log_error("External public key do not exist.");
+		charra_log_error("External public key does not exist.");
 		return CHARRA_RC_ERROR;
 	}
 

--- a/src/core/charra_key_mgr.c
+++ b/src/core/charra_key_mgr.c
@@ -30,17 +30,35 @@
 #include "../util/tpm2_util.h"
 
 CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
-	const uint8_t* key, ESYS_TR* key_handle) {
+	const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public) {
 	TSS2_RC r = TSS2_RC_SUCCESS;
 	if (memcmp(key, "PK.RSA.default", key_len) == 0) {
 		charra_log_info("Loading key \"PK.RSA.default\".");
-		r = tpm2_create_primary_key_rsa2048(ctx, key_handle);
+		r = tpm2_create_primary_key_rsa2048(ctx, key_handle, out_public);
 		if (r != TSS2_RC_SUCCESS) {
 			charra_log_error("Loading of key \"PK.RSA.default\" failed.");
 			return CHARRA_RC_ERROR;
 		}
 	} else {
 		charra_log_error("TPM key not found.");
+		return CHARRA_RC_ERROR;
+	}
+
+	return CHARRA_RC_SUCCESS;
+}
+
+CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
+	TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle) {
+	TSS2_RC r = TSS2_RC_SUCCESS;
+	if (external_public_key == NULL){
+		charra_log_error("External public key do not exist.");
+		return CHARRA_RC_ERROR;
+	}
+
+	r = Esys_LoadExternal(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+			NULL, external_public_key, TPM2_RH_OWNER, key_handle);
+	if (r != TSS2_RC_SUCCESS ){
+		charra_log_error("Loading external public key failed.");
 		return CHARRA_RC_ERROR;
 	}
 

--- a/src/core/charra_key_mgr.h
+++ b/src/core/charra_key_mgr.h
@@ -28,6 +28,9 @@
 #include "../common/charra_error.h"
 
 CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
-	const uint8_t* key, ESYS_TR* key_handle);
+	const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public);
+
+CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
+	TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle);
 
 #endif /* CHARRA_KEY_MGR_H */

--- a/src/core/charra_marshaling.c
+++ b/src/core/charra_marshaling.c
@@ -295,7 +295,7 @@ CHARRA_RC unmarshal_attestation_response(uint32_t marshaled_data_len,
 	memcpy(&(res.tpm2_signature), item.val.string.ptr, res.tpm2_signature_len);
 
 	/* parse "tpm2_public_key (bytes)" */
-	if((cborerr = charra_cbor_getnext(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
 		goto cbor_parse_error;
 	res.tpm2_public_key_len = item.val.string.len;
 	memcpy(

--- a/src/util/tpm2_util.c
+++ b/src/util/tpm2_util.c
@@ -30,7 +30,7 @@
 #include "../common/charra_log.h"
 
 TSS2_RC tpm2_create_primary_key_rsa2048(
-	ESYS_CONTEXT* ctx, ESYS_TR* primary_handle) {
+	ESYS_CONTEXT* ctx, ESYS_TR* primary_handle, TPM2B_PUBLIC** out_public) {
 	TSS2_RC r = TSS2_RC_SUCCESS;
 	char* error_msg = NULL;
 

--- a/src/util/tpm2_util.c
+++ b/src/util/tpm2_util.c
@@ -109,7 +109,7 @@ TSS2_RC tpm2_create_primary_key_rsa2048(
 
 	if ((r = Esys_CreatePrimary(ctx, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
 			 ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublic,
-			 &outsideInfo, &creationPCR, primary_handle, NULL, NULL, NULL,
+			 &outsideInfo, &creationPCR, primary_handle, out_public, NULL, NULL,
 			 NULL)) != TSS2_RC_SUCCESS) {
 		error_msg = "Esys_CreatePrimary";
 		goto error;

--- a/src/util/tpm2_util.h
+++ b/src/util/tpm2_util.h
@@ -34,7 +34,7 @@
  * @return TSS2_RC The TSS return code.
  */
 TSS2_RC tpm2_create_primary_key_rsa2048(
-	ESYS_CONTEXT* ctx, ESYS_TR* primary_handle);
+	ESYS_CONTEXT* ctx, ESYS_TR* primary_handle, TPM2B_PUBLIC** out_public);
 
 /**
  * @brief Stores a key in the TPM NVRAM under the first available NV index.

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -283,12 +283,11 @@ static void coap_attest_handler(struct coap_context_t* context UNUSED,
 
 	/* load TPM key */
 	charra_log_info("[" LOG_NAME "] Loading TPM key.");
-	charra_r = charra_load_external_public_key(esys_ctx, res.tpm2_public_key,
-		&sig_key_handle);
+	charra_r = charra_load_external_public_key(
+		esys_ctx, (TPM2B_PUBLIC*)res.tpm2_public_key, &sig_key_handle);
 	if (charra_r == CHARRA_RC_SUCCESS) {
 		charra_log_info("[" LOG_NAME "] External public key loaded.");
-	}
-	else{
+	} else {
 		charra_log_error("[" LOG_NAME "] Loading external public key failed.");
 		goto error;
 	}

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -283,12 +283,14 @@ static void coap_attest_handler(struct coap_context_t* context UNUSED,
 
 	/* load TPM key */
 	charra_log_info("[" LOG_NAME "] Loading TPM key.");
-	if ((charra_r = charra_load_tpm2_key(esys_ctx, TPM_SIG_KEY_ID_LEN,
-			 (uint8_t*)TPM_SIG_KEY_ID, &sig_key_handle)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Could not load TPM key.");
+	charra_r = charra_load_external_public_key(esys_ctx, res.tpm2_public_key,
+		&sig_key_handle);
+	if (charra_r == CHARRA_RC_SUCCESS) {
+		charra_log_info("[" LOG_NAME "] External public key loaded.");
+	}
+	else{
+		charra_log_error("[" LOG_NAME "] Loading external public key failed.");
 		goto error;
-	} else {
-		charra_log_info("[" LOG_NAME "] Loading of TPM key successful.");
 	}
 
 	/* prepare verification */


### PR DESCRIPTION
The PR is connected to the following issue https://github.com/Fraunhofer-SIT/charra/issues/15.
These changes allow the attester to obtain the public part of the attestation key. The public key is marshaled and sent to the verifier. The verifier loads the external public key and uses it to verify the TPM quote signature.