### PR TITLE
Implemented CLI & a check for the environment variable CHARRA_TCTI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ LDPATH =     -L/usr/local/lib/ \
 LIBS =       coap-2 \
              qcbor m \
              crypto ssl \
-			 mbedcrypto \
-             util tss2-esys tss2-sys tss2-mu
+             mbedcrypto \
+             util tss2-esys tss2-sys tss2-mu tss2-tctildr
 
 # TCTI module to use (default is 'mssim')
 TCTI_MODULE=tss2-tcti-mssim
@@ -59,7 +59,7 @@ INCLUDE = -I$(INCDIR)
 
 OBJECTS =  $(addsuffix .o, $(addprefix $(OBJDIR)/common/, charra_log))
 OBJECTS += $(addsuffix .o, $(addprefix $(OBJDIR)/core/, charra_helper charra_key_mgr charra_rim_mgr charra_marshaling))
-OBJECTS += $(addsuffix .o, $(addprefix $(OBJDIR)/util/, cbor_util charra_util coap_util crypto_util io_util tpm2_util))
+OBJECTS += $(addsuffix .o, $(addprefix $(OBJDIR)/util/, cbor_util charra_util coap_util crypto_util io_util tpm2_util cli_util))
 
 TARGETS = $(addprefix $(BINDIR)/, attester verifier)
 

--- a/src/attester.c
+++ b/src/attester.c
@@ -23,8 +23,10 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <tss2/tss2_mu.h>
+#include <tss2/tss2_tctildr.h>
 #include <tss2/tss2_tpm2_types.h>
 
 #include "common/charra_log.h"
@@ -33,6 +35,7 @@
 #include "core/charra_key_mgr.h"
 #include "core/charra_marshaling.h"
 #include "util/cbor_util.h"
+#include "util/cli_util.h"
 #include "util/coap_util.h"
 #include "util/io_util.h"
 #include "util/tpm2_util.h"
@@ -46,14 +49,18 @@ static bool quit = false;
 
 /* logging */
 #define LOG_NAME "attester"
+coap_log_t coap_log_level = LOG_INFO;
+// #define LOG_LEVEL_CBOR LOG_DEBUG
+charra_log_t charra_log_level = CHARRA_LOG_INFO;
 
 /* config */
 static const char LISTEN_ADDRESS[] = "0.0.0.0";
-static const uint16_t PORT = COAP_DEFAULT_PORT; // default port 5683
-#define CBOR_ENCODER_BUFFER_LENGTH 20480		// 20 KiB should be sufficient
+static unsigned int port = COAP_DEFAULT_PORT; // default port 5683
+#define CBOR_ENCODER_BUFFER_LENGTH 20480	  // 20 KiB should be sufficient
+bool use_ima_event_log = false;
+char* ima_event_log_path =
+	"/sys/kernel/security/ima/binary_runtime_measurements";
 // TODO allocate memory for CBOR buffer using malloc() since logs can be huge
-
-/* --- function forward declarations -------------------------------------- */
 
 /**
  * @brief SIGINT handler: set quit to 1 for graceful termination.
@@ -72,17 +79,52 @@ static void coap_attest_handler(struct coap_context_t* ctx,
 
 /* --- main --------------------------------------------------------------- */
 
-int main(void) {
+int main(int argc, char** argv) {
 	int result = EXIT_FAILURE;
 
 	/* handle SIGINT */
 	signal(SIGINT, handle_sigint);
 
+	/* check environment variables */
+	charra_log_level_from_str(
+		(const char*)getenv("LOG_LEVEL_CHARRA"), &charra_log_level);
+	charra_coap_log_level_from_str(
+		(const char*)getenv("LOG_LEVEL_COAP"), &coap_log_level);
+
+	/* initialize structures to pass to the CLI parser */
+	cli_config cli_config = {
+		.caller = ATTESTER,
+		.common_config =
+			{
+				.charra_log_level = &charra_log_level,
+				.coap_log_level = &coap_log_level,
+				.port = &port,
+			},
+		.attester_config =
+			{
+				.use_ima_event_log = &use_ima_event_log,
+				.ima_event_log_path = &ima_event_log_path,
+			},
+	};
+
+	/* parse CLI arguments */
+	if ((result = parse_command_line_arguments(argc, argv, &cli_config)) != 0) {
+		// 1 means help message is displayed, -1 means error
+		return (result == 1) ? EXIT_SUCCESS : EXIT_FAILURE;
+	}
+
 	/* set CHARRA and libcoap log levels */
-	charra_log_set_level(charra_log_level_from_str(
-		(const char*)getenv("LOG_LEVEL_CHARRA"), CHARRA_LOG_INFO));
-	coap_set_log_level(charra_coap_log_level_from_str(
-		(const char*)getenv("LOG_LEVEL_COAP"), LOG_INFO));
+	charra_log_set_level(charra_log_level);
+	coap_set_log_level(coap_log_level);
+
+	charra_log_debug("[" LOG_NAME "] Attester Configuration:");
+	charra_log_debug("[" LOG_NAME "]     Used local port: %d", port);
+	charra_log_debug("[" LOG_NAME "]     IMA event log attestation enabled: %s",
+		(use_ima_event_log == true) ? "true" : "false");
+	if (use_ima_event_log) {
+		charra_log_debug(
+			"[" LOG_NAME "]     IMA event log path %s", ima_event_log_path);
+	}
 
 	/* create CoAP context */
 	coap_context_t* coap_context = NULL;
@@ -96,7 +138,7 @@ int main(void) {
 	coap_endpoint_t* coap_endpoint = NULL;
 	charra_log_info("[" LOG_NAME "] Creating CoAP server endpoint.");
 	if ((coap_endpoint = charra_coap_new_endpoint(
-			 coap_context, LISTEN_ADDRESS, PORT, COAP_PROTO_UDP)) == NULL) {
+			 coap_context, LISTEN_ADDRESS, port, COAP_PROTO_UDP)) == NULL) {
 		charra_log_error(
 			"[" LOG_NAME "] Cannot create CoAP server endpoint.\n");
 		goto error;
@@ -127,8 +169,8 @@ error:
 finish:
 	/* free CoAP memory */
 	// FIXME Why do the following 2 statements produce a segfault?
-	// coap_free_endpoint(coap_endpoint);
-	// coap_free_context(coap_context);
+	coap_free_endpoint(coap_endpoint);
+	coap_free_context(coap_context);
 	coap_cleanup();
 
 	return result;
@@ -140,7 +182,7 @@ static void handle_sigint(int signum CHARRA_UNUSED) { quit = true; }
 
 static void release_data(
 	struct coap_session_t* session CHARRA_UNUSED, void* app_ptr) {
-	coap_delete_binary(app_ptr);
+	free(app_ptr);
 }
 
 static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
@@ -212,7 +254,14 @@ static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
 
 	/* initialize ESAPI */
 	ESYS_CONTEXT* esys_ctx = NULL;
-	if ((tss_r = Esys_Initialize(&esys_ctx, NULL, NULL)) != TSS2_RC_SUCCESS) {
+	TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
+	if ((tss_r = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
+		TSS2_RC_SUCCESS) {
+		charra_log_error("[" LOG_NAME "] Tss2_TctiLdr_Initialize.");
+		goto error;
+	}
+	if ((tss_r = Esys_Initialize(&esys_ctx, tcti_ctx, NULL)) !=
+		TSS2_RC_SUCCESS) {
 		charra_log_error("[" LOG_NAME "] Esys_Initialize.");
 		goto error;
 	}
@@ -240,15 +289,25 @@ static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
 
 	/* --- send response data --- */
 
-	unsigned char dummy_event_log[] =
-		"--- BEGIN CHARRA EVENT LOG ----------------\n"
-		"This is a dummy event log.\n"
-		"It is here just for demonstration purposes.\n"
-		"--- END CHARRA EVENT LOG ------------------\n";
-	const uint32_t dummy_event_log_len = sizeof(dummy_event_log);
-
 	/* prepare response */
 	charra_log_info("[" LOG_NAME "] Preparing response.");
+	FILE* fp = NULL;
+	long int ima_event_log_len = 0;
+	if (use_ima_event_log == true) {
+		fp = fopen(ima_event_log_path, "r");
+		if (fp == NULL) {
+			charra_log_error("[" LOG_NAME "] IMA list could not be opened.");
+			goto error;
+		}
+		fseek(fp, 0L, SEEK_END);
+		ima_event_log_len = ftell(fp);
+		fseek(fp, 0L, SEEK_SET);
+		charra_log_info(
+			"[" LOG_NAME
+			"] Including IMA event log of size %d bytes in the response.",
+			ima_event_log_len);
+	}
+
 	msg_attestation_response_dto res = {
 		.attestation_data_len = attest_buf->size,
 		.attestation_data = {0}, // must be memcpy'd, see below
@@ -256,12 +315,29 @@ static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
 		.tpm2_signature = {0}, // must be memcpy'd, see below
 		.tpm2_public_key_len = sizeof(*public_key),
 		.tpm2_public_key = {0}, // must be memcpy'd, see below
-		.event_log_len = dummy_event_log_len,
-		.event_log = dummy_event_log};
+		.event_log_len = ima_event_log_len,
+		.event_log = malloc(ima_event_log_len),
+	};
 	memcpy(res.attestation_data, attest_buf->attestationData,
 		res.attestation_data_len);
 	memcpy(res.tpm2_signature, signature, res.tpm2_signature_len);
 	memcpy(res.tpm2_public_key, public_key, res.tpm2_public_key_len);
+	free(signature);
+	signature = NULL;
+	free(attest_buf);
+	attest_buf = NULL;
+	free(public_key);
+	public_key = NULL;
+	if (use_ima_event_log == true) {
+		int read_size = fread(res.event_log, 1, ima_event_log_len, fp);
+		if (read_size != ima_event_log_len) {
+			charra_log_error("[" LOG_NAME "] Expected to read IMA list with "
+							 "size %d, acutally read %d bytes.",
+				ima_event_log_len);
+			goto error;
+		}
+		fclose(fp);
+	}
 
 	/* marshal response */
 	charra_log_info("[" LOG_NAME "] Marshaling response to CBOR.");
@@ -282,6 +358,20 @@ static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
 	}
 
 error:
+	/* Free heap objects */
+	if (signature != NULL) {
+		free(signature);
+	}
+	if (attest_buf != NULL) {
+		free(attest_buf);
+	}
+	if (public_key != NULL) {
+		free(public_key);
+	}
+	if (res.event_log != NULL) {
+		free(res.event_log);
+	}
+
 	/* flush handles */
 	if (sig_key_handle != ESYS_TR_NONE) {
 		if (Esys_FlushContext(esys_ctx, sig_key_handle) != TSS2_RC_SUCCESS) {
@@ -293,5 +383,8 @@ error:
 	/* finalize ESAPI */
 	if (esys_ctx != NULL) {
 		Esys_Finalize(&esys_ctx);
+	}
+	if (tcti_ctx != NULL) {
+		Tss2_TctiLdr_Finalize(&tcti_ctx);
 	}
 }

--- a/src/common/charra_log.c
+++ b/src/common/charra_log.c
@@ -28,12 +28,16 @@ static struct {
 	void* udata;
 	charra_log_LockFn lock;
 	FILE* fp;
-	int level;
+	charra_log_t level;
 	int quiet;
 } L;
 
-static const char* charra_level_names[] = {
-	"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"};
+static const char* const charra_level_names[6] = {[CHARRA_LOG_TRACE] = "TRACE",
+	[CHARRA_LOG_DEBUG] = "DEBUG",
+	[CHARRA_LOG_INFO] = "INFO",
+	[CHARRA_LOG_WARN] = "WARN",
+	[CHARRA_LOG_ERROR] = "ERROR",
+	[CHARRA_LOG_FATAL] = "FATAL"};
 
 #ifndef CHARRA_LOG_DISABLE_COLOR
 static const char* charra_level_colors[] = {
@@ -58,12 +62,12 @@ void charra_log_set_lock(charra_log_LockFn fn) { L.lock = fn; }
 
 void charra_log_set_fp(FILE* fp) { L.fp = fp; }
 
-void charra_log_set_level(int level) { L.level = level; }
+void charra_log_set_level(charra_log_t level) { L.level = level; }
 
 void charra_log_set_quiet(int enable) { L.quiet = enable ? 1 : 0; }
 
 void charra_log_log(
-	int level, const char* file, int line, const char* fmt, ...) {
+	charra_log_t level, const char* file, int line, const char* fmt, ...) {
 	if (level < L.level) {
 		return;
 	}
@@ -112,23 +116,23 @@ void charra_log_log(
 	charra_log_unlock();
 }
 
-charra_log_t charra_log_level_from_str(
-	const char* log_level_str, const charra_log_t default_log_level) {
+int charra_log_level_from_str(
+	const char* log_level_str, charra_log_t* log_level) {
 	if (log_level_str != NULL) {
-		if (strncmp(log_level_str, "TRACE", 5) == 0) {
-			return CHARRA_LOG_TRACE;
-		} else if (strncmp(log_level_str, "DEBUG", 5) == 0) {
-			return CHARRA_LOG_DEBUG;
-		} else if (strncmp(log_level_str, "INFO", 4) == 0) {
-			return CHARRA_LOG_INFO;
-		} else if (strncmp(log_level_str, "WARN", 4) == 0) {
-			return CHARRA_LOG_WARN;
-		} else if (strncmp(log_level_str, "ERROR", 5) == 0) {
-			return CHARRA_LOG_ERROR;
-		} else if (strncmp(log_level_str, "FATAL", 5) == 0) {
-			return CHARRA_LOG_FATAL;
+		int array_size =
+			sizeof(charra_level_names) / sizeof(charra_level_names[0]);
+		for (int i = 0; i < array_size; i++) {
+			const char* name = charra_level_names[i];
+			if (name == NULL) {
+				continue;
+			}
+			if (strcmp(name, log_level_str) == 0) {
+				*log_level = i;
+				return 0;
+			}
 		}
+		return -1;
 	}
 
-	return default_log_level;
+	return -1;
 }

--- a/src/common/charra_log.h
+++ b/src/common/charra_log.h
@@ -67,23 +67,22 @@ typedef enum {
 void charra_log_set_udata(void* udata);
 void charra_log_set_lock(charra_log_LockFn fn);
 void charra_log_set_fp(FILE* fp);
-void charra_log_set_level(int level);
+void charra_log_set_level(charra_log_t level);
 void charra_log_set_quiet(int enable);
 
 void charra_log_log(
-	int level, const char* file, int line, const char* fmt, ...);
+	charra_log_t level, const char* file, int line, const char* fmt, ...);
 
 /**
- * @brief Parses the CHARRA log level from string and returns the appropriate
- * enum constant. A default log level must be provided in case there is no match
- * for the string respresentation.
+ * @brief Parses the CHARRA log level from string and writes the result into
+ * variable log_level. In case of an parsing error nothing is written and the
+ * function returns -1.
  *
  * @param[in] log_level_str the CHARRA log level string.
- * @param[in] default_log_level the default CHARRA log level in case
- * there is no match for the string respresentation.
- * @return charra_log_t the CHARRA log level.
+ * @param[out] log_level the variable into which the result is written.
+ * @return 0 on success, -1 on error.
  */
-charra_log_t charra_log_level_from_str(
-	const char* log_level_str, const charra_log_t default_log_level);
+int charra_log_level_from_str(
+	const char* log_level_str, charra_log_t* log_level);
 
 #endif /* CHARRA_LOG_H */

--- a/src/core/charra_helper.h
+++ b/src/core/charra_helper.h
@@ -41,7 +41,8 @@ CHARRA_RC charra_tpm2_pcr_selection_to_bitmap(const uint32_t pcr_selection_len,
 	const uint8_t pcr_selection[], TPMS_PCR_SELECTION* pcr_selection_bitmap);
 
 CHARRA_RC charra_pcr_selections_to_tpm_pcr_selections(
-	const uint32_t pcr_selection_list_len, pcr_selection_dto* pcr_selection_list,
+	const uint32_t pcr_selection_list_len,
+	pcr_selection_dto* pcr_selection_list,
 	TPML_PCR_SELECTION* tpm_pcr_selections);
 
 #endif /* CHARRA_HELPER_H */

--- a/src/core/charra_key_mgr.c
+++ b/src/core/charra_key_mgr.c
@@ -47,17 +47,17 @@ CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
 	return CHARRA_RC_SUCCESS;
 }
 
-CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
-	TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle) {
+CHARRA_RC charra_load_external_public_key(
+	ESYS_CONTEXT* ctx, TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle) {
 	TSS2_RC r = TSS2_RC_SUCCESS;
-	if (external_public_key == NULL){
+	if (external_public_key == NULL) {
 		charra_log_error("External public key does not exist.");
 		return CHARRA_RC_ERROR;
 	}
 
-	r = Esys_LoadExternal(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-			NULL, external_public_key, TPM2_RH_OWNER, key_handle);
-	if (r != TSS2_RC_SUCCESS ){
+	r = Esys_LoadExternal(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, NULL,
+		external_public_key, TPM2_RH_OWNER, key_handle);
+	if (r != TSS2_RC_SUCCESS) {
 		charra_log_error("Loading external public key failed.");
 		return CHARRA_RC_ERROR;
 	}

--- a/src/core/charra_key_mgr.h
+++ b/src/core/charra_key_mgr.h
@@ -30,7 +30,7 @@
 CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
 	const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public);
 
-CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
-	TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle);
+CHARRA_RC charra_load_external_public_key(
+	ESYS_CONTEXT* ctx, TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle);
 
 #endif /* CHARRA_KEY_MGR_H */

--- a/src/core/charra_marshaling.c
+++ b/src/core/charra_marshaling.c
@@ -50,7 +50,8 @@ CHARRA_RC marshal_attestation_request(
 	assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
 	assert(attestation_request->nonce != NULL);
 
-	UsefulBuf_MAKE_STACK_UB(buf, CBOR_ENCODER_BUFFER_LENGTH);
+	UsefulBuf buf = {.len = CBOR_ENCODER_BUFFER_LENGTH,
+		.ptr = malloc(CBOR_ENCODER_BUFFER_LENGTH)};
 	QCBOREncodeContext ec;
 
 	QCBOREncode_Init(&ec, buf);
@@ -218,7 +219,8 @@ CHARRA_RC marshal_attestation_response(
 	assert(attestation_response->tpm2_public_key != NULL);
 	assert(attestation_response->event_log != NULL);
 
-	UsefulBuf_MAKE_STACK_UB(buf, CBOR_ENCODER_BUFFER_LENGTH);
+	UsefulBuf buf = {.len = CBOR_ENCODER_BUFFER_LENGTH,
+		.ptr = malloc(CBOR_ENCODER_BUFFER_LENGTH)};
 	QCBOREncodeContext ec = {0};
 
 	QCBOREncode_Init(&ec, buf);
@@ -270,8 +272,8 @@ CHARRA_RC unmarshal_attestation_response(const uint32_t marshaled_data_len,
 
 	QCBORError cborerr = QCBOR_SUCCESS;
 	UsefulBufC marshaled_data_buf = {marshaled_data, marshaled_data_len};
-	QCBORDecodeContext dc;
-	QCBORItem item;
+	QCBORDecodeContext dc = {0};
+	QCBORItem item = {0};
 
 	QCBORDecode_Init(&dc, marshaled_data_buf, QCBOR_DECODE_MODE_NORMAL);
 

--- a/src/core/charra_marshaling.h
+++ b/src/core/charra_marshaling.h
@@ -24,8 +24,8 @@
 #include <qcbor/qcbor.h>
 #include <tss2/tss2_esys.h>
 
-#include "../core/charra_dto.h"
 #include "../common/charra_error.h"
+#include "../core/charra_dto.h"
 
 /**
  * @brief Marshals an attestation request DTO.
@@ -50,7 +50,8 @@ CHARRA_RC marshal_attestation_request(
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC unmarshal_attestation_request(const uint32_t marshaled_data_len,
-	const uint8_t* marshaled_data, msg_attestation_request_dto* attestation_request);
+	const uint8_t* marshaled_data,
+	msg_attestation_request_dto* attestation_request);
 
 /**
  * @brief Marshals an attestation response DTO.

--- a/src/util/cli_util.c
+++ b/src/util/cli_util.c
@@ -1,0 +1,194 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*****************************************************************************
+ * Copyright 2021, Fraunhofer Institute for Secure Information Technology SIT.
+ * All rights reserved.
+ ****************************************************************************/
+
+/**
+ * @file command_line_util.c
+ * @author Dominik Lorych (dominik.lorych@sit.fraunhofer.de)
+ * @brief Provides command line parsing for verifier & attester.
+ * @version 0.1
+ * @date 2021-02-18
+ *
+ * @copyright Copyright 2021, Fraunhofer Institute for Secure Information
+ * Technology SIT. All rights reserved.
+ *
+ * @license BSD 3-Clause "New" or "Revised" License (SPDX-License-Identifier:
+ * BSD-3-Clause).
+ */
+
+#include "cli_util.h"
+
+#include "../common/charra_log.h"
+#include "coap_util.h"
+#include "io_util.h"
+#include <getopt.h>
+#include <stdlib.h>
+
+/* command line argument handling */
+static const struct option verifier_options[] = {{"help", no_argument, 0, 'h'},
+	{"verbose", no_argument, 0, 'v'}, {"log-level", required_argument, 0, 'l'},
+	{"coap-log-level", required_argument, 0, 'c'},
+	{"port", required_argument, 0, 'p'}, {"ip", required_argument, 0, 'i'},
+	{"timeout", required_argument, 0, 't'}, {0}};
+
+static const struct option attester_options[] = {{"help", no_argument, 0, 'h'},
+	{"verbose", no_argument, 0, 'v'}, {"log-level", optional_argument, 0, 'l'},
+	{"coap-log-level", optional_argument, 0, 'c'},
+	{"port", required_argument, 0, 'p'}, {"ima", optional_argument, 0, 'i'},
+	{0}};
+
+int parse_command_line_arguments(int argc, char** argv, cli_config* variables) {
+	cli_parser_caller caller = variables->caller;
+	char* log_name;
+	if (caller == VERIFIER) {
+		log_name = "verifier";
+	} else {
+		log_name = "attester";
+	}
+	for (;;) {
+		int index = -1;
+		int identifier = getopt_long(argc, argv, "hv",
+			((caller == VERIFIER) ? verifier_options : attester_options),
+			&index);
+
+		if (identifier == -1)
+			return 0; // end of command line arguments reached
+
+		if (identifier == 'h' || identifier == '?') {
+			// '?' means that an error appeared while parsing
+			if (identifier == '?') {
+				printf("[%s] Error while parsing argument '%s' or '%s'!\n",
+					log_name, argv[index], optarg);
+			}
+			// print help message
+			printf("Usage: %s [OPTIONS]\n", log_name);
+			printf(" -h, --help:                 Print this help message.\n");
+			printf(" -v, --verbose:              Set CHARRA and CoAP log-level "
+				   "to DEBUG.\n");
+			printf(
+				"     --log-level=LEVEL:      Set CHARRA log-level to LEVEL. "
+				"Available are: TRACE, DEBUG, INFO, WARN, ERROR, FATAL. "
+				"Default is INFO.\n");
+			printf("     --coap-log-level=LEVEL: Set CoAP log-level to LEVEL. "
+				   "Available are: DEBUG, INFO, NOTICE, WARNING, ERR, CRIT, "
+				   "ALERT, EMERG, CIPHERS. Default is INFO.\n");
+			if (caller == VERIFIER) {
+				printf("     --ip=IP:                Connect to IP instead of "
+					   "doing the attestation on localhost.\n");
+				printf("     --port=PORT:            Connect to PORT instead "
+					   "of port %d.\n",
+					*(variables->common_config.port));
+				printf("     --timeout=SECONDS:      Wait up to SECONDS for "
+					   "the attestation answer. Default is %d.\n",
+					*(variables->verifier_config.timeout));
+			} else {
+				printf("     --port=PORT:            Open PORT instead of port "
+					   "%d.\n",
+					*(variables->common_config.port));
+				printf("     --ima[=PATH]:           Enable attestation of ima "
+					   "event logs. "
+					   "By default IMA uses the file '%s'. Alternatives can be "
+					   "passed.\n",
+					*(variables->attester_config.ima_event_log_path));
+			}
+			printf("To specify TCTI commands for the TPM, set the "
+				   "'CHARRA_TCTI' environment variable accordingly.\n");
+			return (identifier == '?') ? -1 : 1;
+		}
+
+		else if (identifier == 'v') { // verbose logging
+			*(variables->common_config.charra_log_level) = CHARRA_LOG_DEBUG;
+			*(variables->common_config.coap_log_level) = LOG_DEBUG;
+			continue;
+		}
+
+		else if (identifier == 'l') { // set log level for charra
+			int result = charra_log_level_from_str(
+				optarg, variables->common_config.charra_log_level);
+			if (result != 0) {
+				printf("[%s] Error while parsing '-l/--log-level': "
+					   "Unrecognized argument %s\n",
+					log_name, optarg);
+				return -1;
+			}
+			continue;
+		}
+
+		else if (identifier == 'c') { // set log level for libcoap
+			int result = charra_coap_log_level_from_str(
+				optarg, variables->common_config.coap_log_level);
+			if (result != 0) {
+				printf("[%s] Error while parsing '-l/--log-level': "
+					   "Unrecognized argument %s\n",
+					log_name, optarg);
+				return -1;
+			}
+			continue;
+		}
+
+		else if (identifier == 'p') { // set port
+			char* end;
+			*(variables->common_config.port) =
+				(unsigned int)strtoul(optarg, &end, 10);
+			if (*(variables->common_config.port) == 0 || end == optarg) {
+				printf("[%s] Error while parsing '--port': Port could not be "
+					   "parsed\n",
+					log_name);
+				return -1;
+			}
+			continue;
+		}
+
+		else if (caller == VERIFIER) {
+
+			if (identifier == 'i') { // set IP address
+				int argument_length = strlen(optarg);
+				if (argument_length > 15) {
+					printf("[%s] Error while parsing '--ip': Input too long "
+						   "for IPv4 address\n",
+						log_name);
+					return -1;
+				}
+				strncpy(variables->verifier_config.dst_host, optarg, 16);
+				continue;
+			}
+
+			else if (identifier == 't') {
+				char* end;
+				*(variables->verifier_config.timeout) =
+					(uint16_t)strtoul(optarg, &end, 10);
+				if (*(variables->verifier_config.timeout) == 0 ||
+					end == optarg) {
+					printf("[%s] Error while parsing '--port': Port could not "
+						   "be parsed\n",
+						log_name);
+					return -1;
+				}
+				continue;
+			}
+
+		}
+
+		else if (caller == ATTESTER) {
+
+			if (identifier == 'i') { // set IMA event log on
+				*(variables->attester_config.use_ima_event_log) = true;
+				if (optarg != NULL) {
+					*(variables->attester_config.ima_event_log_path) =
+						malloc(strlen(optarg) + 1);
+					strncpy(*(variables->attester_config.ima_event_log_path),
+						optarg, strlen(optarg));
+				}
+				continue;
+			}
+		}
+
+		// undefined behaviour, probably because getopt_long returned an
+		// identifier which is not checked here
+		printf("[%s] Error: Undefined behaviour while parsing command line\n",
+			log_name);
+		return -1;
+	}
+}

--- a/src/util/cli_util.h
+++ b/src/util/cli_util.h
@@ -1,0 +1,79 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*****************************************************************************
+ * Copyright 2021, Fraunhofer Institute for Secure Information Technology SIT.
+ * All rights reserved.
+ ****************************************************************************/
+
+/**
+ * @file command_line_util.h
+ * @author Dominik Lorych (dominik.lorych@sit.fraunhofer.de)
+ * @brief Provides command line parsing for verifier & attester.
+ * @version 0.1
+ * @date 2021-02-18
+ *
+ * @copyright Copyright 2021, Fraunhofer Institute for Secure Information
+ * Technology SIT. All rights reserved.
+ *
+ * @license BSD 3-Clause "New" or "Revised" License (SPDX-License-Identifier:
+ * BSD-3-Clause).
+ */
+
+#include "../common/charra_log.h"
+#include <coap2/coap.h>
+#include <stdbool.h>
+
+typedef enum {
+	VERIFIER,
+	ATTESTER,
+} cli_parser_caller;
+
+/**
+ * A structure holding pointers to common variables of attester and verifier
+ * which might geht modified by the CLI parser
+ */
+typedef struct {
+	charra_log_t* charra_log_level;
+	coap_log_t* coap_log_level;
+	unsigned int* port;
+} cli_config_common;
+
+/**
+ * A structure holding pointers to variables of the attester
+ * which might geht modified by the CLI parser
+ */
+typedef struct {
+	bool* use_ima_event_log;
+	char** ima_event_log_path;
+} cli_config_attester;
+
+/**
+ * A structure holding pointers to variables of the verifier
+ * which might geht modified by the CLI parser
+ */
+typedef struct {
+	char* dst_host;
+	uint16_t* timeout;
+} cli_config_verifier;
+
+/**
+ * A structure holding the pointers to all config parameters which might get
+ * modified by the CLI parser
+ */
+typedef struct {
+	cli_parser_caller caller;
+	cli_config_common common_config;
+	cli_config_attester attester_config;
+	cli_config_verifier verifier_config;
+} cli_config;
+
+/**
+*  @brief parses command line interface arguments
+*
+* @param argc The number of arguments which were given to the CLI.
+* @param argv The arguments which were given to the CLI.
+* @param variables A struct holding a caller identifier and pointers to config
+				   variables which might get modified depending on the CLI
+arguments.
+* @return 0 on success, -1 on parse error, 1 when help message was displayed
+*/
+int parse_command_line_arguments(int argc, char** argv, cli_config* variables);

--- a/src/util/coap_util.c
+++ b/src/util/coap_util.c
@@ -29,6 +29,16 @@
 
 #define LOG_NAME "coap-util"
 
+static const char* const coap_level_names[10] = {[LOG_EMERG] = "EMERG",
+	[LOG_ALERT] = "ALERT",
+	[LOG_CRIT] = "CRIT",
+	[LOG_ERR] = "ERR",
+	[LOG_WARNING] = "WARNING",
+	[LOG_NOTICE] = "NOTICE",
+	[LOG_INFO] = "INFO",
+	[LOG_DEBUG] = "DEBUG",
+	[COAP_LOG_CIPHERS] = "CIPHERS"};
+
 /* --- function definitions ----------------------------------------------- */
 
 coap_context_t* charra_coap_new_context(const bool enable_coap_block_mode) {
@@ -143,38 +153,32 @@ void charra_coap_add_resource(struct coap_context_t* coap_context,
 	charra_log_info("[" LOG_NAME "] Adding CoAP %s resource '%s'.",
 		charra_coap_method_to_str(method), resource_name);
 
-	coap_str_const_t* resource_uri = coap_make_str_const(resource_name);
+	coap_str_const_t* resource_uri = coap_new_str_const(
+		(uint8_t const*)resource_name, strlen(resource_name));
 	coap_resource_t* resource =
 		coap_resource_init(resource_uri, COAP_RESOURCE_FLAGS_RELEASE_URI);
 	coap_register_handler(resource, method, handler);
 	coap_add_resource(coap_context, resource);
 }
 
-coap_log_t charra_coap_log_level_from_str(
-	const char* log_level_str, coap_log_t default_log_level) {
+int charra_coap_log_level_from_str(
+	const char* log_level_str, coap_log_t* log_level) {
 	if (log_level_str != NULL) {
-		if (strncmp(log_level_str, "EMERG", 5) == 0) {
-			return LOG_EMERG;
-		} else if (strncmp(log_level_str, "ALERT", 5) == 0) {
-			return LOG_ALERT;
-		} else if (strncmp(log_level_str, "CRIT", 4) == 0) {
-			return LOG_CRIT;
-		} else if (strncmp(log_level_str, "ERR", 3) == 0) {
-			return LOG_ERR;
-		} else if (strncmp(log_level_str, "WARNING", 7) == 0) {
-			return LOG_WARNING;
-		} else if (strncmp(log_level_str, "NOTICE", 6) == 0) {
-			return LOG_NOTICE;
-		} else if (strncmp(log_level_str, "INFO", 4) == 0) {
-			return LOG_INFO;
-		} else if (strncmp(log_level_str, "DEBUG", 5) == 0) {
-			return LOG_DEBUG;
-		} else if (strncmp(log_level_str, "CIPHERS", 7) == 0) {
-			return COAP_LOG_CIPHERS;
+		int array_size = sizeof(coap_level_names) / sizeof(coap_level_names[0]);
+		for (int i = 0; i < array_size; i++) {
+			const char* name = coap_level_names[i];
+			if (name == NULL) {
+				continue;
+			}
+			if (strcmp(name, log_level_str) == 0) {
+				*log_level = i;
+				return 0;
+			}
 		}
+		return -1;
 	}
 
-	return default_log_level;
+	return -1;
 }
 
 const char* charra_coap_method_to_str(const coap_request_t method) {

--- a/src/util/coap_util.h
+++ b/src/util/coap_util.h
@@ -135,17 +135,16 @@ void charra_coap_add_resource(struct coap_context_t* coap_context,
 	const coap_method_handler_t handler);
 
 /**
- * @brief Parses the libcoap log level from string and returns the
- * appropriate enum constant. A default log level must be provided in case
- * there is no match for the string respresentation.
+ * @brief Parses the libcoap log level from string and writes the result into
+ * variable log_level. In case of an parsing error nothing is written and the
+ * function returns -1.
  *
  * @param[in] log_level_str the libcoap log level string.
- * @param[in] default_log_level the default libcoap log level in case
- * there is no match for the string respresentation.
- * @return charra_log_t the libcoap log level.
+ * @param[out] log_level the variable into which the log level is written.
+ * @return 0 on success, -1 on error.
  */
-coap_log_t charra_coap_log_level_from_str(
-	const char* log_level_str, const coap_log_t default_log_level);
+int charra_coap_log_level_from_str(
+	const char* log_level_str, coap_log_t* log_level);
 
 /**
  * @brief Returns the string representation of a CoAP request method.

--- a/src/util/io_util.h
+++ b/src/util/io_util.h
@@ -26,15 +26,11 @@
 #include <stdint.h>
 
 #define CHARRA_BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
-#define CHARRA_BYTE_TO_BINARY(byte)  \
-  (byte & 0x80 ? '1' : '0'), \
-  (byte & 0x40 ? '1' : '0'), \
-  (byte & 0x20 ? '1' : '0'), \
-  (byte & 0x10 ? '1' : '0'), \
-  (byte & 0x08 ? '1' : '0'), \
-  (byte & 0x04 ? '1' : '0'), \
-  (byte & 0x02 ? '1' : '0'), \
-  (byte & 0x01 ? '1' : '0')
+#define CHARRA_BYTE_TO_BINARY(byte)                                            \
+	(byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'),                      \
+		(byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'),                  \
+		(byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'),                  \
+		(byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0')
 
 /**
  * @brief


### PR DESCRIPTION
Added CLI with options for logging, destination IP address and port, length of timeout when waiting for attestation response and IMA event logging. Call attester or verifier with --help for details.
Environment variable CHARRA_TCTI now gets checked and passed on to the tss2-tcti.