### PR TITLE
Fixed waiting for attestation response.

### DIFF
--- a/src/attester.c
+++ b/src/attester.c
@@ -332,7 +332,7 @@ static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
 		int read_size = fread(res.event_log, 1, ima_event_log_len, fp);
 		if (read_size != ima_event_log_len) {
 			charra_log_error("[" LOG_NAME "] Expected to read IMA list with "
-										  "size %d, acutally read %d bytes.",
+							 "size %d, acutally read %d bytes.",
 				ima_event_log_len);
 			goto error;
 		}


### PR DESCRIPTION
The previous implementation could end unexpectedly because it just waited for the next CoAP io process action. This action was assumed to be the attestation response, but this did not always hold true. Now the implementation explicitly checks if the attestation is finished.