### PR TITLE
Dynamic memory allocation for QCBOR encoded data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ This is a proof-of-concept implementation of the "Challenge/Response Remote Atte
 
 This proof-of-concept implementation realizes the Attesting Computing Environment—a Computing Environment capable of monitoring and attesting a target Computing Environment—as well as the target Computing Environment itself, as described in the [RATS Architecture](https://datatracker.ietf.org/doc/draft-ietf-rats-architecture/).
 
+## Changelog 2021-03-17
 
-## Changelog 2020-03-16 (v2)
+* Dynamic memory allocation for QCBOR encoded data using *malloc()*.
+  Thanks, @laurencelundblade.
+
+* Fixed some bugs.
+
+* Introduced macros for `free()`'ing heap data.
+
+## Changelog 2021-03-16 (v2)
 
 * Added random nonce generation with mbed TLS in Verifier.
   Made it configurable whether to use the TPM or mbed TLS to generate the nonce.
@@ -15,7 +23,7 @@ This proof-of-concept implementation realizes the Attesting Computing Environmen
 * Added media type CBOR to attestation request in Verifier.
   Credits go to @mrdeep1.
 
-## Changelog 2020-03-16
+## Changelog 2021-03-16 (v1)
 
 * Updated `README.md` to include building *tpm2software/tpm2-tss* Docker image which CHARRA uses as a basis.
   Reason: recently, the official *tpm2software/tpm2-tss* Docker images were removed from [Docker Hub](https://hub.docker.com/r/tpm2software/tpm2-tss).
@@ -28,7 +36,7 @@ This proof-of-concept implementation realizes the Attesting Computing Environmen
 
 * Added compressed CHARRA SVG logo (`*.svgz`). See [charra-logo.svgz](./charra-logo.svgz).
 
-## Changelog 2020-03-10
+## Changelog 2021-03-10
 
 * Added support for CoAP large/block-wise data transfers, utilizing latest features of [libcoap](https://github.com/obgm/libcoap).
   This enables CHARRA to send and receive data of arbitrary size.
@@ -88,9 +96,6 @@ This proof-of-concept implementation realizes the Attesting Computing Environmen
 * Use non-zero reference PCRs.
 * "Extended" *TPM Quote* using TPM audit session(s) and *TPM PCR Read* operations.
 * Make CHARRA a library (`libcharra`) and make *attester* and *verifier* example code in `example` folder.
-* Dynamic allocation for QCBOR encoded data:
-  > You pass a UsefulBuf that has a NULL pointer and size set to SIZE_MAX to QCBOREncode_Init() and then do the encode just like when you do it for real.
-  > See documentation for QCBOREncode_Init(). — Laurence Lundblade (developer of QCBOR)
 * Add `*_free()` functions for all data transfer objects (DTOs).
 * Introduce semantic versioning as CHARRA develops along the way to become stable.
 

--- a/src/common/charra_log.h
+++ b/src/common/charra_log.h
@@ -27,13 +27,13 @@
 
 typedef void (*charra_log_LockFn)(void* udata, int lock);
 
-typedef enum {
-	CHARRA_LOG_TRACE,
-	CHARRA_LOG_DEBUG,
-	CHARRA_LOG_INFO,
-	CHARRA_LOG_WARN,
-	CHARRA_LOG_ERROR,
-	CHARRA_LOG_FATAL,
+typedef enum charra_log_t {
+	CHARRA_LOG_TRACE = 0,
+	CHARRA_LOG_DEBUG = 1,
+	CHARRA_LOG_INFO = 2,
+	CHARRA_LOG_WARN = 3,
+	CHARRA_LOG_ERROR = 4,
+	CHARRA_LOG_FATAL = 5,
 } charra_log_t;
 
 #if (!CHARRA_LOG_DISABLE)

--- a/src/common/charra_macro.h
+++ b/src/common/charra_macro.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*****************************************************************************
+ * Copyright 2021, Fraunhofer Institute for Secure Information Technology SIT.
+ * All rights reserved.
+ ****************************************************************************/
+
+/**
+ * @file charra_macro.h
+ * @author Michael Eckel (michael.eckel@sit.fraunhofer.de)
+ * @brief General macros.
+ * @version 0.1
+ * @date 2021-03-17
+ *
+ * @copyright Copyright 2019, Fraunhofer Institute for Secure Information
+ * Technology SIT. All rights reserved.
+ *
+ * @license BSD 3-Clause "New" or "Revised" License (SPDX-License-Identifier:
+ * BSD-3-Clause).
+ */
+
+#ifndef CHARRA_MACRO_H
+#define CHARRA_MACRO_H
+
+#include <stdlib.h>
+
+#define charra_free_and_null(var)                                              \
+	{                                                                          \
+		free(var);                                                             \
+		var = NULL;                                                            \
+	}
+
+#define charra_free_and_null_ex(var, func_name)                                \
+	{                                                                          \
+		func_name(var);                                                        \
+		var = NULL;                                                            \
+	}
+
+#define charra_free_if_not_null(var)                                           \
+	{                                                                          \
+		if (var != NULL) {                                                     \
+			charra_free_and_null(var);                                         \
+		}                                                                      \
+	}
+
+#define charra_free_if_not_null_ex(var, func_name)                             \
+	{                                                                          \
+		if (var != NULL) {                                                     \
+			charra_free_and_null_ex(var, func_name);                           \
+		}                                                                      \
+	}
+
+#endif /* CHARRA_MACRO_H */

--- a/src/core/charra_marshaling.c
+++ b/src/core/charra_marshaling.c
@@ -30,15 +30,14 @@
 #include <tss2/tss2_tpm2_types.h>
 
 #include "../common/charra_log.h"
+#include "../common/charra_macro.h"
 #include "../core/charra_dto.h"
 #include "../util/cbor_util.h"
 #include "../util/tpm2_util.h"
 
-static const uint32_t CBOR_ENCODER_BUFFER_LENGTH = 20480;
-
-CHARRA_RC marshal_attestation_request(
-	const msg_attestation_request_dto* attestation_request,
-	uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
+static CHARRA_RC charra_marshal_attestation_request_internal(
+	const msg_attestation_request_dto* attestation_request, UsefulBuf buf_in,
+	UsefulBufC* buf_out) {
 	charra_log_trace("<ENTER> %s()", __func__);
 
 	/* verify input */
@@ -50,11 +49,9 @@ CHARRA_RC marshal_attestation_request(
 	assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
 	assert(attestation_request->nonce != NULL);
 
-	UsefulBuf buf = {.len = CBOR_ENCODER_BUFFER_LENGTH,
-		.ptr = malloc(CBOR_ENCODER_BUFFER_LENGTH)};
-	QCBOREncodeContext ec;
+	QCBOREncodeContext ec = {0};
 
-	QCBOREncode_Init(&ec, buf);
+	QCBOREncode_Init(&ec, buf_in);
 
 	/* root array */
 	QCBOREncode_OpenArray(&ec);
@@ -72,58 +69,111 @@ CHARRA_RC marshal_attestation_request(
 		attestation_request->nonce, attestation_request->nonce_len};
 	QCBOREncode_AddBytes(&ec, nonce);
 
-	{ /* encode "pcr-selections" */
+	/* encode "pcr-selections" */
+	QCBOREncode_OpenArray(&ec);
+	for (uint32_t i = 0; i < attestation_request->pcr_selections_len; ++i) {
 		QCBOREncode_OpenArray(&ec);
+		QCBOREncode_AddInt64(
+			&ec, attestation_request->pcr_selections[i].tcg_hash_alg_id);
+		{
+			/* open array: pcrs_array_encoder */
+			QCBOREncode_OpenArray(&ec);
+			for (uint32_t j = 0;
+				 j < attestation_request->pcr_selections[i].pcrs_len; ++j) {
 
-		for (uint32_t i = 0; i < attestation_request->pcr_selections_len; ++i) {
-			{
-				QCBOREncode_OpenArray(&ec);
-
-				QCBOREncode_AddInt64(&ec,
-					attestation_request->pcr_selections[i].tcg_hash_alg_id);
-
-				{
-					QCBOREncode_OpenArray(&ec);
-
-					for (uint32_t j = 0;
-						 j < attestation_request->pcr_selections[i].pcrs_len;
-						 ++j) {
-
-						QCBOREncode_AddUInt64(&ec,
-							attestation_request->pcr_selections[i].pcrs[j]);
-					}
-
-					/* close array: pcrs_array_encoder */
-					QCBOREncode_CloseArray(&ec);
-				}
-
-				/* close array: pcr_selection_array_encoder */
-				QCBOREncode_CloseArray(&ec);
+				QCBOREncode_AddUInt64(
+					&ec, attestation_request->pcr_selections[i].pcrs[j]);
 			}
+			/* close array: pcrs_array_encoder */
+			QCBOREncode_CloseArray(&ec);
 		}
-
-		/* close array: pcr_selections_array_encoder */
+		/* close array: pcr_selection_array_encoder */
 		QCBOREncode_CloseArray(&ec);
 	}
+
+	/* close array: pcr_selections_array_encoder */
+	QCBOREncode_CloseArray(&ec);
 
 	/* close array: root_array_encoder */
 	QCBOREncode_CloseArray(&ec);
 
-	/* set out params */
-	UsefulBufC encoded = {0};
-
-	if (QCBOREncode_Finish(&ec, &encoded)) {
+	if (QCBOREncode_Finish(&ec, buf_out) == QCBOR_SUCCESS) {
+		return CHARRA_RC_SUCCESS;
+	} else {
 		return CHARRA_RC_MARSHALING_ERROR;
 	}
-
-	*marshaled_data_len = encoded.len;
-	*marshaled_data = (uint8_t*)encoded.ptr;
-
-	return CHARRA_RC_SUCCESS;
 }
 
-CHARRA_RC unmarshal_attestation_request(const uint32_t marshaled_data_len,
-	const uint8_t* marshaled_data,
+CHARRA_RC charra_marshal_attestation_request_size(
+	const msg_attestation_request_dto* attestation_request,
+	size_t* marshaled_data_len) {
+	charra_log_trace("<ENTER> %s()", __func__);
+
+	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+
+	/* passing this buffer instructs QCBOR to return only the size and do no
+	 * actual encoding */
+	UsefulBuf buf_in = {.len = SIZE_MAX, .ptr = NULL};
+	UsefulBufC buf_out = {0};
+
+	if ((charra_r = charra_marshal_attestation_request_internal(
+			 attestation_request, buf_in, &buf_out)) == CHARRA_RC_SUCCESS) {
+		*marshaled_data_len = buf_out.len;
+	}
+
+	return charra_r;
+}
+
+CHARRA_RC charra_marshal_attestation_request(
+	const msg_attestation_request_dto* attestation_request,
+	uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
+	charra_log_trace("<ENTER> %s()", __func__);
+
+	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+
+	/* verify input */
+	assert(attestation_request != NULL);
+	assert(attestation_request->pcr_selections_len <= TPM2_NUM_PCR_BANKS);
+	assert(attestation_request->pcr_selections != NULL);
+	assert(attestation_request->pcr_selections->pcrs_len <= TPM2_MAX_PCRS);
+	assert(attestation_request->pcr_selections->pcrs != NULL);
+	assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
+	assert(attestation_request->nonce != NULL);
+
+	/* compute size of marshaled data */
+	UsefulBuf buf_in = {.len = 0, .ptr = NULL};
+	if ((charra_r = charra_marshal_attestation_request_size(
+			 attestation_request, &(buf_in.len))) != CHARRA_RC_SUCCESS) {
+		charra_log_error("Could not compute size of marshaled data.");
+		return charra_r;
+	}
+	charra_log_debug("Size of marshaled data is %zu bytes.", buf_in.len);
+
+	/* allocate buffer size */
+	if ((buf_in.ptr = malloc(buf_in.len)) == NULL) {
+		charra_log_error("Allocating %zu bytes of memory failed.", buf_in.len);
+		return CHARRA_RC_MARSHALING_ERROR;
+	}
+	charra_log_debug("Allocated %zu bytes of memory.", buf_in.len);
+
+	/* encode */
+	UsefulBufC buf_out = {.len = 0, .ptr = NULL};
+	if ((charra_r = charra_marshal_attestation_request_internal(
+			 attestation_request, buf_in, &buf_out)) != CHARRA_RC_SUCCESS) {
+		charra_log_error("Could not marshal data.");
+		return charra_r;
+	}
+
+	/* set output parameters */
+	*marshaled_data_len = buf_out.len;
+	*marshaled_data = (uint8_t*)buf_out.ptr;
+
+	return charra_r;
+}
+
+// TODO implement this function using QCBOREncode_* functions
+CHARRA_RC charra_unmarshal_attestation_request(
+	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
 	msg_attestation_request_dto* attestation_request) {
 	msg_attestation_request_dto req = {0};
 
@@ -206,10 +256,9 @@ cbor_parse_error:
 	return CHARRA_RC_MARSHALING_ERROR;
 }
 
-CHARRA_RC marshal_attestation_response(
-	const msg_attestation_response_dto* attestation_response,
-	uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
-
+static CHARRA_RC charra_marshal_attestation_response_internal(
+	const msg_attestation_response_dto* attestation_response, UsefulBuf buf_in,
+	UsefulBufC* buf_out) {
 	charra_log_trace("<ENTER> %s()", __func__);
 
 	/* verify input */
@@ -221,11 +270,9 @@ CHARRA_RC marshal_attestation_response(
 		assert(attestation_response->event_log != NULL);
 	}
 
-	UsefulBuf buf = {.len = CBOR_ENCODER_BUFFER_LENGTH,
-		.ptr = malloc(CBOR_ENCODER_BUFFER_LENGTH)};
 	QCBOREncodeContext ec = {0};
 
-	QCBOREncode_Init(&ec, buf);
+	QCBOREncode_Init(&ec, buf_in);
 
 	/* root array */
 	QCBOREncode_OpenArray(&ec);
@@ -254,21 +301,83 @@ CHARRA_RC marshal_attestation_response(
 	/* close array: root_array_encoder */
 	QCBOREncode_CloseArray(&ec);
 
-	/* set out params */
-	UsefulBufC encoded = {0};
-
-	if (QCBOREncode_Finish(&ec, &encoded)) {
+	if (QCBOREncode_Finish(&ec, buf_out) == QCBOR_SUCCESS) {
+		return CHARRA_RC_SUCCESS;
+	} else {
 		return CHARRA_RC_MARSHALING_ERROR;
 	}
-
-	*marshaled_data_len = encoded.len;
-	*marshaled_data = (uint8_t*)encoded.ptr;
-
-	return CHARRA_RC_SUCCESS;
 }
 
-CHARRA_RC unmarshal_attestation_response(const uint32_t marshaled_data_len,
-	const uint8_t* marshaled_data,
+CHARRA_RC charra_marshal_attestation_response_size(
+	const msg_attestation_response_dto* attestation_response,
+	size_t* marshaled_data_len) {
+	charra_log_trace("<ENTER> %s()", __func__);
+
+	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+
+	/* passing this buffer instructs QCBOR to return only the size and do no
+	 * actual encoding */
+	UsefulBuf buf_in = {.len = SIZE_MAX, .ptr = NULL};
+	UsefulBufC buf_out = {0};
+
+	if ((charra_r = charra_marshal_attestation_response_internal(
+			 attestation_response, buf_in, &buf_out)) == CHARRA_RC_SUCCESS) {
+		*marshaled_data_len = buf_out.len;
+	}
+
+	return charra_r;
+}
+
+CHARRA_RC charra_marshal_attestation_response(
+	const msg_attestation_response_dto* attestation_response,
+	uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
+	charra_log_trace("<ENTER> %s()", __func__);
+
+	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+
+	/* verify input */
+	assert(attestation_response != NULL);
+	assert(attestation_response->attestation_data != NULL);
+	assert(attestation_response->tpm2_signature != NULL);
+	assert(attestation_response->tpm2_public_key != NULL);
+	if (attestation_response->event_log_len != 0) {
+		assert(attestation_response->event_log != NULL);
+	}
+
+	/* compute size of marshaled data */
+	UsefulBuf buf_in = {.len = 0, .ptr = NULL};
+	if ((charra_r = charra_marshal_attestation_response_size(
+			 attestation_response, &(buf_in.len))) != CHARRA_RC_SUCCESS) {
+		charra_log_error("Could not compute size of marshaled data.");
+		return charra_r;
+	}
+	charra_log_debug("Size of marshaled data is %zu bytes.", buf_in.len);
+
+	/* allocate buffer size */
+	if ((buf_in.ptr = malloc(buf_in.len)) == NULL) {
+		charra_log_error("Allocating %zu bytes of memory failed.", buf_in.len);
+		return CHARRA_RC_MARSHALING_ERROR;
+	}
+	charra_log_debug("Allocated %zu bytes of memory.", buf_in.len);
+
+	/* encode */
+	UsefulBufC buf_out = {.len = 0, .ptr = NULL};
+	if ((charra_r = charra_marshal_attestation_response_internal(
+			 attestation_response, buf_in, &buf_out)) != CHARRA_RC_SUCCESS) {
+		charra_log_error("Could not marshal data.");
+		return charra_r;
+	}
+
+	/* set output parameters */
+	*marshaled_data_len = buf_out.len;
+	*marshaled_data = (uint8_t*)buf_out.ptr;
+
+	return charra_r;
+}
+
+// TODO implement this function using  QCBORDecode_* functions
+CHARRA_RC charra_unmarshal_attestation_response(
+	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
 	msg_attestation_response_dto* attestation_response) {
 	msg_attestation_response_dto res = {0};
 
@@ -333,10 +442,8 @@ cbor_parse_error:
 	charra_log_error("CBOR parser: %s", qcbor_err_to_str(cborerr));
 	charra_log_info("CBOR parser: skipping parsing.");
 
-	/* free */
-	if (event_log != NULL) {
-		free(event_log);
-	}
+	/* clean up */
+	charra_free_if_not_null(event_log);
 
 	return CHARRA_RC_MARSHALING_ERROR;
 }

--- a/src/core/charra_marshaling.h
+++ b/src/core/charra_marshaling.h
@@ -36,7 +36,7 @@
  * @return CHARRA_RC_SUCCESS on success.
  * @return CHARRA_RC_ERROR on error.
  */
-CHARRA_RC marshal_attestation_request(
+CHARRA_RC charra_marshal_attestation_request(
 	const msg_attestation_request_dto* attestation_request,
 	uint32_t* marshaled_data_len, uint8_t** marshaled_data);
 
@@ -49,8 +49,8 @@ CHARRA_RC marshal_attestation_request(
  * @return CHARRA_RC_SUCCESS on success.
  * @return CHARRA_RC_ERROR on error.
  */
-CHARRA_RC unmarshal_attestation_request(const uint32_t marshaled_data_len,
-	const uint8_t* marshaled_data,
+CHARRA_RC charra_unmarshal_attestation_request(
+	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
 	msg_attestation_request_dto* attestation_request);
 
 /**
@@ -62,7 +62,7 @@ CHARRA_RC unmarshal_attestation_request(const uint32_t marshaled_data_len,
  * @return CHARRA_RC_SUCCESS on success.
  * @return CHARRA_RC_ERROR on error.
  */
-CHARRA_RC marshal_attestation_response(
+CHARRA_RC charra_marshal_attestation_response(
 	const msg_attestation_response_dto* attestation_response,
 	uint32_t* marshaled_data_len, uint8_t** marshaled_data);
 
@@ -75,8 +75,8 @@ CHARRA_RC marshal_attestation_response(
  * @return CHARRA_RC_SUCCESS on success.
  * @return CHARRA_RC_ERROR on error.
  */
-CHARRA_RC unmarshal_attestation_response(const uint32_t marshaled_data_len,
-	const uint8_t* marshaled_data,
+CHARRA_RC charra_unmarshal_attestation_response(
+	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
 	msg_attestation_response_dto* attestation_response);
 
 #endif /* MARSHALING_UTIL_H */


### PR DESCRIPTION
Fixes #36.

* Dynamic memory allocation for QCBOR encoded data using *malloc()*.
  Thanks, @laurencelundblade.

* Fixed some bugs.

* Introduced macros for `free()`'ing heap data.

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>