### PR TITLE
Fixes size of `attestation_data` field.

### DIFF
--- a/src/core/charra_dto.h
+++ b/src/core/charra_dto.h
@@ -86,7 +86,7 @@ typedef struct {
 typedef struct {
 	// TODO Use tpms_attest_dto attestation_data;
 	uint32_t attestation_data_len;
-	uint8_t attestation_data[sizeof(TPMS_ATTEST)];
+	uint8_t attestation_data[sizeof(TPM2B_ATTEST)];
 	uint32_t tpm2_signature_len;
 	uint8_t tpm2_signature[sizeof(TPMT_SIGNATURE)];
 	uint32_t tpm2_public_key_len;


### PR DESCRIPTION
Fixes #46.

The `attestation_data` field in struct `msg_attestation_request_dto`
must be of size `sizeof(TPM2B_ATTEST)` rather than `sizeof(TPMS_ATTEST)`
as assigned by the attester (`attest_buf` is of type `TPM2B_ATTEST`).

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>