### PR TITLE
New location of tpm2-software docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Hint: Check your Dockerfile at https://www.fromlatest.io/                  #
 ##############################################################################
 
-FROM tpm2software/tpm2-tss:ubuntu-20.04 AS base
+FROM ghcr.io/tpm2-software/ubuntu-20.04:latest AS base
 LABEL maintainer="Michael Eckel <michael.eckel@sit.fraunhofer.de>"
 
 ## glocal arguments with default values


### PR DESCRIPTION
The original image of tpm2-software on Docker-Hub does not exist anymore. If you take a look at their [group](https://github.com/tpm2-software/) you'll find [tpm2-software-container](https://github.com/tpm2-software/tpm2-software-container) as a repository. The last point in the [README](https://github.com/tpm2-software/tpm2-software-container/blob/master/README.md) points out that the built images were moved to [a new location](https://github.com/orgs/tpm2-software/packages). If you then open the [ubuntu 20.04 link](https://github.com/tpm2-software/tpm2-software-container/pkgs/container/ubuntu-20.04) you'll see that you can pull the image with the following command `docker pull ghcr.io/tpm2-software/ubuntu-20.04:latest`. So if the dockerfile is updated to `FROM ghcr.io/tpm2-software/ubuntu-20.04:latest AS base` the container will build without the need of cloning [tpm2-tss](https://github.com/tpm2-software/tpm2-tss) repo and building it locally.