### PR TITLE
Fix memory leak when reading files.

### DIFF
--- a/src/attester.c
+++ b/src/attester.c
@@ -467,7 +467,7 @@ error:
 	charra_free_if_not_null(signature);
 	charra_free_if_not_null(attest_buf);
 	charra_free_if_not_null(public_key);
-	charra_free_continous_file_buffer(&ima_event_log);
+	charra_io_free_continuous_file_buffer(&ima_event_log);
 
 	/* flush handles */
 	if (sig_key_handle != ESYS_TR_NONE) {

--- a/src/util/cli_util.c
+++ b/src/util/cli_util.c
@@ -274,7 +274,7 @@ int parse_command_line_arguments(int argc, char** argv, cli_config* variables) {
 			*variables->common_config.use_dtls_rpk = true;
 			char* path = malloc(strlen(optarg));
 			strcpy(path, optarg);
-			if (check_file_existence(path) == CHARRA_RC_SUCCESS) {
+			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
 				*(variables->common_config.dtls_rpk_private_key_path) = path;
 				continue;
 			} else {
@@ -289,7 +289,7 @@ int parse_command_line_arguments(int argc, char** argv, cli_config* variables) {
 			*variables->common_config.use_dtls_rpk = true;
 			char* path = malloc(strlen(optarg));
 			strcpy(path, optarg);
-			if (check_file_existence(path) == CHARRA_RC_SUCCESS) {
+			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
 				*(variables->common_config.dtls_rpk_public_key_path) = path;
 				continue;
 			} else {
@@ -304,7 +304,7 @@ int parse_command_line_arguments(int argc, char** argv, cli_config* variables) {
 			*variables->common_config.use_dtls_rpk = true;
 			char* path = malloc(strlen(optarg));
 			strcpy(path, optarg);
-			if (check_file_existence(path) == CHARRA_RC_SUCCESS) {
+			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
 				*(variables->common_config.dtls_rpk_peer_public_key_path) =
 					path;
 				continue;
@@ -363,7 +363,7 @@ int parse_command_line_arguments(int argc, char** argv, cli_config* variables) {
 			uint32_t length = strlen(optarg);
 			char* path = malloc(length * sizeof(char));
 			strcpy(path, optarg);
-			if (check_file_existence(path) == CHARRA_RC_SUCCESS) {
+			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
 				*(variables->verifier_config.reference_pcr_file_path) = path;
 				continue;
 			} else {

--- a/src/util/io_util.c
+++ b/src/util/io_util.c
@@ -27,10 +27,11 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <unistd.h>
 
 void charra_print_hex(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* prefix, const char* postfix,
-	const bool upper_case) {
+	const uint8_t* const buf, const char* const prefix,
+	const char* const postfix, const bool upper_case) {
 	const char* const hex_case = upper_case ? "%02X" : "%02x";
 
 	charra_log_log_raw(level, "%s", prefix);
@@ -42,7 +43,8 @@ void charra_print_hex(const charra_log_t level, const size_t buf_len,
 }
 
 void charra_print_str(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* prefix, const char* postfix) {
+	const uint8_t* const buf, const char* const prefix,
+	const char* const postfix) {
 
 	charra_log_log_raw(level, "%s", prefix);
 	/* print upper case */
@@ -53,8 +55,8 @@ void charra_print_str(const charra_log_t level, const size_t buf_len,
 }
 
 void charra_print_pcr_content(const charra_log_t level,
-	const uint8_t* pcr_selection, const uint32_t pcr_selection_len,
-	uint8_t** pcrs) {
+	const uint8_t* const pcr_selection, const uint32_t pcr_selection_len,
+	const uint8_t** const pcrs) {
 	for (uint32_t i = 0; i < pcr_selection_len; i++) {
 		charra_log_log_raw(level, "%02d: 0x", pcr_selection[i]);
 		for (uint32_t j = 0; j < TPM2_SHA256_DIGEST_SIZE; j++) {
@@ -64,59 +66,95 @@ void charra_print_pcr_content(const charra_log_t level,
 	}
 }
 
-CHARRA_RC check_file_existence(const char* filename) {
-	FILE* fp = NULL;
-	if ((fp = fopen(filename, "r")) == NULL) {
+CHARRA_RC charra_io_file_exists(const char* const filename) {
+	if (access(filename, F_OK) == 0) {
+		return CHARRA_RC_SUCCESS;
+	} else {
 		return CHARRA_RC_ERROR;
 	}
-	return CHARRA_RC_SUCCESS;
 }
 
-CHARRA_RC charra_io_read_file(
-	const char* filename, char** file_content, size_t* file_content_len) {
+CHARRA_RC charra_io_read_file(const char* filename, char** const file_content,
+	size_t* const file_content_len) {
+	CHARRA_RC r = CHARRA_RC_SUCCESS;
 	FILE* fp = NULL;
+
+	/* open file */
 	if ((fp = fopen(filename, "r")) == NULL) {
 		charra_log_error("Cannot open file '%s'.", filename);
-		return CHARRA_RC_ERROR;
+		r = CHARRA_RC_ERROR;
+		goto error;
 	}
-	fseek(fp, 0L, SEEK_END);
-	size_t file_size = ftell(fp);
-	fseek(fp, 0L, SEEK_SET);
-	char* file_buffer = malloc(file_size * sizeof(char));
+
+	/* get file size */
+	ssize_t file_size = -1;
+	{
+		/* go to end of file */
+		if (fseek(fp, 0L, SEEK_END) != 0) {
+			r = CHARRA_RC_ERROR;
+			goto error;
+		}
+
+		/* get position (i.e., the file size) */
+		if ((file_size = ftell(fp)) == -1) {
+			r = CHARRA_RC_ERROR;
+			goto error;
+		}
+
+		/* go back to beginning of file */
+		if (fseek(fp, 0L, SEEK_SET) != 0) {
+			r = CHARRA_RC_ERROR;
+			goto error;
+		}
+	}
+
+	/* allocate memory */
+	char* file_buffer = NULL;
+	if ((file_buffer = malloc(file_size * sizeof(*file_buffer))) == NULL) {
+		r = CHARRA_RC_ERROR;
+		goto error;
+	}
+
 	size_t read_size = fread(file_buffer, sizeof(*file_buffer), file_size, fp);
-	if (read_size < file_size) {
+	if (read_size < (size_t)file_size) {
 		charra_log_error(
-			"Error while reading file '%s', expected size %d, got size %d.",
+			"Error while reading file '%s', expected size %zu, got size %zu.",
 			filename, file_size, read_size);
 		charra_free_if_not_null(file_buffer);
-		return CHARRA_RC_ERROR;
+		r = CHARRA_RC_ERROR;
+		goto error;
 	}
-	/* flush and close file */
-	if (fflush(fp) != 0) {
-		charra_log_error("Error flushing file '%s'.", filename);
-		charra_free_if_not_null(file_buffer);
-		return CHARRA_RC_ERROR;
-	}
-	if (fclose(fp) != 0) {
-		charra_log_error("Error closing file '%s'.", filename);
-		charra_free_if_not_null(file_buffer);
-		return CHARRA_RC_ERROR;
-	}
+
+	/* set output arguments */
 	*file_content = file_buffer;
 	*file_content_len = read_size;
-	return CHARRA_RC_SUCCESS;
+
+error:
+
+	/* close file */
+	if (fp != NULL) {
+		if (fclose(fp) != 0) {
+			charra_log_error("Error closing file '%s'.", filename);
+			charra_free_if_not_null(file_buffer);
+			return CHARRA_RC_ERROR;
+		}
+	}
+
+	return r;
 }
 
-void charra_free_file_buffer(char** file_content) {
+void charra_io_free_file_buffer(char** const file_content) {
 	charra_free_if_not_null(*file_content);
 }
 
-CHARRA_RC charra_io_read_continuous_binary_file(
-	const char* filename, uint8_t** file_content, size_t* file_content_len) {
-	// the size of the event log chunks which get read at once
+CHARRA_RC charra_io_read_continuous_binary_file(const char* const filename,
+	uint8_t** const file_content, size_t* const file_content_len) {
+	/* the size of the event log chunks which get read at once */
 #define IMA_EVENT_LOG_STEP_SIZE 1024
-	// use logarithmic growth for the cvector. Otherwise it would grow on
-	// every cvector_push_back() call
+	/*
+	 * Use logarithmic growth for the cvector. Otherwise it would grow on
+	 * every call to cvector_push_back().
+	 */
 #define CVECTOR_LOGARITHMIC_GROWTH
 
 	cvector_vector_type(uint8_t) file_content_cvector = NULL;
@@ -151,6 +189,6 @@ CHARRA_RC charra_io_read_continuous_binary_file(
 	return CHARRA_RC_SUCCESS;
 }
 
-void charra_free_continous_file_buffer(uint8_t** file_content) {
+void charra_io_free_continuous_file_buffer(uint8_t** const file_content) {
 	charra_free_if_not_null_ex(*file_content, cvector_free);
 }

--- a/src/util/io_util.h
+++ b/src/util/io_util.h
@@ -48,8 +48,8 @@
  * in lowercase (e.g. "012..abcdef").
  */
 void charra_print_hex(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* prefix, const char* postfix,
-	const bool upper_case);
+	const uint8_t* const buf, const char* const prefix,
+	const char* const postfix, const bool upper_case);
 
 /**
  * @brief
@@ -62,7 +62,8 @@ void charra_print_hex(const charra_log_t level, const size_t buf_len,
  * @param postfix  A postfix to the output, e.g. "\n", or leave it empty ("").
  */
 void charra_print_str(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* prefix, const char* postfix);
+	const uint8_t* const buf, const char* const prefix,
+	const char* const postfix);
 
 /**
  * @brief Print PCR content of selected PCRs.
@@ -73,15 +74,15 @@ void charra_print_str(const charra_log_t level, const size_t buf_len,
  * @param pcrs the content of the PCRs
  */
 void charra_print_pcr_content(const charra_log_t level,
-	const uint8_t* pcr_selection, const uint32_t pcr_selection_len,
-	uint8_t** pcrs);
+	const uint8_t* const pcr_selection, const uint32_t pcr_selection_len,
+	const uint8_t** const pcrs);
 
 /**
  * @brief Checks if file is existing.
  *
  * @param filename the path of the file
  */
-CHARRA_RC check_file_existence(const char* filename);
+CHARRA_RC charra_io_file_exists(const char* const filename);
 
 /**
  * @brief read file into a buffer. The buffer will be initialized in this
@@ -94,8 +95,8 @@ CHARRA_RC check_file_existence(const char* filename);
  * file_content).
  * @return CHARRA_RC CHARRA_RC_SUCCESS on success, otherwise CHARRA_RC_ERROR
  */
-CHARRA_RC charra_io_read_file(
-	const char* filename, char** file_content, size_t* file_content_len);
+CHARRA_RC charra_io_read_file(const char* filename, char** const file_content,
+	size_t* const file_content_len);
 
 /**
  * @brief free buffer holding the file content. Alternatively
@@ -103,7 +104,7 @@ CHARRA_RC charra_io_read_file(
  *
  * @param[in] file_content A pointer to the buffer.
  */
-void charra_free_file_buffer(char** file_content);
+void charra_io_free_file_buffer(char** const file_content);
 
 /**
  * @brief read binary file of unknown length into a cvector. Used for IMA event
@@ -117,14 +118,14 @@ void charra_free_file_buffer(char** file_content);
  * file_content).
  * @return CHARRA_RC CHARRA_RC_SUCCESS on success, otherwise CHARRA_RC_ERROR
  */
-CHARRA_RC charra_io_read_continuous_binary_file(
-	const char* filename, uint8_t** file_content, size_t* file_content_len);
+CHARRA_RC charra_io_read_continuous_binary_file(const char* const filename,
+	uint8_t** const file_content, size_t* const file_content_len);
 
 /**
  * @brief free cvector holding the file content.
  *
  * @param[in] file_content A pointer to the cvector.
  */
-void charra_free_continous_file_buffer(uint8_t** file_content);
+void charra_io_free_continuous_file_buffer(uint8_t** const file_content);
 
 #endif /* IO_UTIL_H */


### PR DESCRIPTION
Fixes #56.

- Fixed a (potential) memory leak when reading files. File was not closed correctly in some cases, so I fixed this (hopefully in all cases).
- Prefixed IO functions correctly.
- Fixed typo ("continuous") in io_util.c/.h files.