### PR TITLE
Adjusted code indentation by using spaces instead of tabs.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,8 +2,8 @@ Standard: Cpp11
 BasedOnStyle: LLVM
 IndentWidth: 4
 TabWidth: 4
-UseTab: true
-ContinuationIndentWidth: 4
+UseTab: false
+ContinuationIndentWidth: 8
 ColumnLimit: 80
 AccessModifierOffset: -4
 NamespaceIndentation: All
@@ -21,8 +21,9 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyNamespace: false
   SplitEmptyRecord: false
+BreakBeforeBraces: Custom
 AlignAfterOpenBracket: DontAlign
 PointerAlignment: Left
 ReflowComments: true
 BreakStringLiterals: true
-
+SpacesBeforeTrailingComments: 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,16 +2,15 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-# Use 4 spaces for the Python files
 [*.h,*.c]
-indent_style = tab
+indent_style = space
 indent_size = 4
 max_line_length = 80
 
@@ -21,3 +20,4 @@ indent_style = tab
 
 [*.md]
 trim_trailing_whitespace = true
+

--- a/src/attester.c
+++ b/src/attester.c
@@ -57,15 +57,15 @@ charra_log_t charra_log_level = CHARRA_LOG_INFO;
 
 /* config */
 static const char LISTEN_ADDRESS[] = "0.0.0.0";
-static unsigned int port = COAP_DEFAULT_PORT; // default port 5683
-#define CBOR_ENCODER_BUFFER_LENGTH 20480	  // 20 KiB should be sufficient
+static unsigned int port = COAP_DEFAULT_PORT;  // default port 5683
+#define CBOR_ENCODER_BUFFER_LENGTH 20480       // 20 KiB should be sufficient
 bool use_ima_event_log = false;
 char* ima_event_log_path =
-	"/sys/kernel/security/ima/binary_runtime_measurements";
+        "/sys/kernel/security/ima/binary_runtime_measurements";
 bool use_dtls_psk = false;
 char* dtls_psk_key = "Charra DTLS Key";
 char* dtls_psk_hint = "Charra Attester";
-// TODO allocate memory for CBOR buffer using malloc() since logs can be huge
+// TODO(any): Allocate memory for CBOR buffer with malloc() as logs can be huge.
 
 // for DTLS-RPK
 bool use_dtls_rpk = false;
@@ -82,197 +82,194 @@ bool dtls_rpk_verify_peer_public_key = true;
 static void handle_sigint(int signum);
 
 static void release_data(
-	struct coap_session_t* session CHARRA_UNUSED, void* app_ptr);
+        struct coap_session_t* session CHARRA_UNUSED, void* app_ptr);
 
 static void coap_attest_handler(struct coap_context_t* ctx,
-	struct coap_resource_t* resource, struct coap_session_t* session,
-	struct coap_pdu_t* in_pdu, struct coap_binary_t* token,
-	struct coap_string_t* query, struct coap_pdu_t* out_pdu);
+        struct coap_resource_t* resource, struct coap_session_t* session,
+        struct coap_pdu_t* in_pdu, struct coap_binary_t* token,
+        struct coap_string_t* query, struct coap_pdu_t* out_pdu);
 
 /* --- main --------------------------------------------------------------- */
 
 int main(int argc, char** argv) {
-	int result = EXIT_FAILURE;
+    int result = EXIT_FAILURE;
 
-	/* handle SIGINT */
-	signal(SIGINT, handle_sigint);
+    /* handle SIGINT */
+    signal(SIGINT, handle_sigint);
 
-	/* check environment variables */
-	charra_log_level_from_str(
-		(const char*)getenv("LOG_LEVEL_CHARRA"), &charra_log_level);
-	charra_coap_log_level_from_str(
-		(const char*)getenv("LOG_LEVEL_COAP"), &coap_log_level);
+    /* check environment variables */
+    charra_log_level_from_str(
+            (const char*)getenv("LOG_LEVEL_CHARRA"), &charra_log_level);
+    charra_coap_log_level_from_str(
+            (const char*)getenv("LOG_LEVEL_COAP"), &coap_log_level);
 
-	/* initialize structures to pass to the CLI parser */
-	cli_config cli_config = {
-		.caller = ATTESTER,
-		.common_config =
-			{
-				.charra_log_level = &charra_log_level,
-				.coap_log_level = &coap_log_level,
-				.port = &port,
-				.use_dtls_psk = &use_dtls_psk,
-				.dtls_psk_key = &dtls_psk_key,
-				.use_dtls_rpk = &use_dtls_rpk,
-				.dtls_rpk_private_key_path = &dtls_rpk_private_key_path,
-				.dtls_rpk_public_key_path = &dtls_rpk_public_key_path,
-				.dtls_rpk_peer_public_key_path = &dtls_rpk_peer_public_key_path,
-				.dtls_rpk_verify_peer_public_key =
-					&dtls_rpk_verify_peer_public_key,
-			},
-		.attester_config =
-			{
-				.dtls_psk_hint = &dtls_psk_hint,
-			},
-	};
+    /* initialize structures to pass to the CLI parser */
+    /* clang-format off */
+    cli_config cli_config = {
+        .caller = ATTESTER,
+        .common_config = {
+            .charra_log_level = &charra_log_level,
+            .coap_log_level = &coap_log_level,
+            .port = &port,
+            .use_dtls_psk = &use_dtls_psk,
+            .dtls_psk_key = &dtls_psk_key,
+            .use_dtls_rpk = &use_dtls_rpk,
+            .dtls_rpk_private_key_path =
+                    &dtls_rpk_private_key_path,
+            .dtls_rpk_public_key_path =
+                    &dtls_rpk_public_key_path,
+            .dtls_rpk_peer_public_key_path =
+                    &dtls_rpk_peer_public_key_path,
+            .dtls_rpk_verify_peer_public_key =
+                    &dtls_rpk_verify_peer_public_key,
+        },
+        .attester_config = {
+            .dtls_psk_hint = &dtls_psk_hint,
+        },
+    };
+    /* clang-format on */
 
-	/* parse CLI arguments */
-	if ((result = parse_command_line_arguments(argc, argv, &cli_config)) != 0) {
-		// 1 means help message is displayed, -1 means error
-		return (result == 1) ? EXIT_SUCCESS : EXIT_FAILURE;
-	}
+    /* parse CLI arguments */
+    if ((result = parse_command_line_arguments(argc, argv, &cli_config)) != 0) {
+        // 1 means help message is displayed, -1 means error
+        return (result == 1) ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
 
-	/* set CHARRA and libcoap log levels */
-	charra_log_set_level(charra_log_level);
-	coap_set_log_level(coap_log_level);
+    /* set CHARRA and libcoap log levels */
+    charra_log_set_level(charra_log_level);
+    coap_set_log_level(coap_log_level);
 
-	charra_log_debug("[" LOG_NAME "] Attester Configuration:");
-	charra_log_debug("[" LOG_NAME "]     Used local port: %d", port);
-	charra_log_debug("[" LOG_NAME "]     DTLS-PSK enabled: %s",
-		(use_dtls_psk == true) ? "true" : "false");
-	if (use_dtls_psk) {
-		charra_log_debug("[" LOG_NAME "]         Pre-shared key: '%s'",
-			dtls_psk_key);
-		charra_log_debug(
-			"[" LOG_NAME "]         Hint: '%s'", dtls_psk_hint);
-	}
-	charra_log_debug("[" LOG_NAME "]     DTLS-RPK enabled: %s",
-		(use_dtls_rpk == true) ? "true" : "false");
-	if (use_dtls_rpk) {
-		charra_log_debug("[" LOG_NAME
-						 "]         Private key path: '%s'",
-			dtls_rpk_private_key_path);
-		charra_log_debug("[" LOG_NAME
-						 "]         Public key path: '%s'",
-			dtls_rpk_public_key_path);
-		charra_log_debug("[" LOG_NAME
-						 "]         Peers' public key path: '%s'",
-			dtls_rpk_peer_public_key_path);
-	}
+    charra_log_debug("[" LOG_NAME "] Attester Configuration:");
+    charra_log_debug("[" LOG_NAME "]     Used local port: %d", port);
+    charra_log_debug("[" LOG_NAME "]     DTLS-PSK enabled: %s",
+            (use_dtls_psk == true) ? "true" : "false");
+    if (use_dtls_psk) {
+        charra_log_debug(
+                "[" LOG_NAME "]         Pre-shared key: '%s'", dtls_psk_key);
+        charra_log_debug("[" LOG_NAME "]         Hint: '%s'", dtls_psk_hint);
+    }
+    charra_log_debug("[" LOG_NAME "]     DTLS-RPK enabled: %s",
+            (use_dtls_rpk == true) ? "true" : "false");
+    if (use_dtls_rpk) {
+        charra_log_debug("[" LOG_NAME "]         Private key path: '%s'",
+                dtls_rpk_private_key_path);
+        charra_log_debug("[" LOG_NAME "]         Public key path: '%s'",
+                dtls_rpk_public_key_path);
+        charra_log_debug("[" LOG_NAME "]         Peers' public key path: '%s'",
+                dtls_rpk_peer_public_key_path);
+    }
 
-	/* set varaibles here such that they are valid in case of an 'goto error' */
-	coap_context_t* coap_context = NULL;
-	coap_endpoint_t* coap_endpoint = NULL;
+    /* set varaibles here such that they are valid in case of an 'goto error' */
+    coap_context_t* coap_context = NULL;
+    coap_endpoint_t* coap_endpoint = NULL;
 
-	if (use_dtls_psk && use_dtls_rpk) {
-		charra_log_error(
-			"[" LOG_NAME "] Configuration enables both DTSL with PSK "
-			"and DTSL with PKI. Aborting!");
-		goto error;
-	}
+    if (use_dtls_psk && use_dtls_rpk) {
+        charra_log_error(
+                "[" LOG_NAME "] Configuration enables both DTSL with PSK "
+                "and DTSL with PKI. Aborting!");
+        goto error;
+    }
 
-	if (use_dtls_psk || use_dtls_rpk) {
-		// print TLS version when in debug mode
-		coap_show_tls_version(LOG_DEBUG);
-	}
+    if (use_dtls_psk || use_dtls_rpk) {
+        // print TLS version when in debug mode
+        coap_show_tls_version(LOG_DEBUG);
+    }
 
-	if ((use_dtls_psk || use_dtls_psk) && !coap_dtls_is_supported()) {
-		charra_log_error("[" LOG_NAME "] CoAP does not support DTLS but the "
-						 "configuration enables DTLS. Aborting!");
-		goto error;
-	}
+    if ((use_dtls_psk || use_dtls_psk) && !coap_dtls_is_supported()) {
+        charra_log_error("[" LOG_NAME "] CoAP does not support DTLS but the "
+                         "configuration enables DTLS. Aborting!");
+        goto error;
+    }
 
-	charra_log_info("[" LOG_NAME "] Initializing CoAP in block-wise mode.");
-	if ((coap_context = charra_coap_new_context(true)) == NULL) {
-		charra_log_error("[" LOG_NAME "] Cannot create CoAP context.");
-		goto error;
-	}
+    charra_log_info("[" LOG_NAME "] Initializing CoAP in block-wise mode.");
+    if ((coap_context = charra_coap_new_context(true)) == NULL) {
+        charra_log_error("[" LOG_NAME "] Cannot create CoAP context.");
+        goto error;
+    }
 
-	if (use_dtls_psk) {
-		charra_log_info(
-			"[" LOG_NAME "] Creating CoAP server endpoint using DTLS-PSK.");
-		if (!coap_context_set_psk(coap_context, dtls_psk_hint,
-				(uint8_t*)dtls_psk_key, strlen(dtls_psk_key))) {
-			charra_log_error(
-				"[" LOG_NAME "] Error while configuring CoAP to use DTLS-PSK.");
-			goto error;
-		}
+    if (use_dtls_psk) {
+        charra_log_info(
+                "[" LOG_NAME "] Creating CoAP server endpoint using DTLS-PSK.");
+        if (!coap_context_set_psk(coap_context, dtls_psk_hint,
+                    (uint8_t*)dtls_psk_key, strlen(dtls_psk_key))) {
+            charra_log_error("[" LOG_NAME
+                             "] Error while configuring CoAP to use DTLS-PSK.");
+            goto error;
+        }
 
-		if ((coap_endpoint = charra_coap_new_endpoint(coap_context,
-				 LISTEN_ADDRESS, port, COAP_PROTO_DTLS)) == NULL) {
-			charra_log_error(
-				"[" LOG_NAME
-				"] Cannot create CoAP server endpoint based on DTLS-PSK.\n");
-			goto error;
-		}
-	} else if (use_dtls_rpk) {
-		charra_log_info(
-			"[" LOG_NAME "] Creating CoAP server endpoint using DTLS-RPK.");
-		coap_dtls_pki_t dtls_pki = {0};
+        if ((coap_endpoint = charra_coap_new_endpoint(coap_context,
+                     LISTEN_ADDRESS, port, COAP_PROTO_DTLS)) == NULL) {
+            charra_log_error("[" LOG_NAME "] Cannot create CoAP server "
+                             "endpoint based on DTLS-PSK.\n");
+            goto error;
+        }
+    } else if (use_dtls_rpk) {
+        charra_log_info(
+                "[" LOG_NAME "] Creating CoAP server endpoint using DTLS-RPK.");
+        coap_dtls_pki_t dtls_pki = {0};
 
-		CHARRA_RC rc = charra_coap_setup_dtls_pki_for_rpk(&dtls_pki,
-			dtls_rpk_private_key_path, dtls_rpk_public_key_path,
-			dtls_rpk_peer_public_key_path, dtls_rpk_verify_peer_public_key);
-		if (rc != CHARRA_RC_SUCCESS) {
-			charra_log_error(
-				"[" LOG_NAME "] Error while setting up DTLS-RPK structure.");
-			goto error;
-		}
+        CHARRA_RC rc = charra_coap_setup_dtls_pki_for_rpk(&dtls_pki,
+                dtls_rpk_private_key_path, dtls_rpk_public_key_path,
+                dtls_rpk_peer_public_key_path, dtls_rpk_verify_peer_public_key);
+        if (rc != CHARRA_RC_SUCCESS) {
+            charra_log_error("[" LOG_NAME
+                             "] Error while setting up DTLS-RPK structure.");
+            goto error;
+        }
 
-		if (!coap_context_set_pki(coap_context, &dtls_pki)) {
-			charra_log_error(
-				"[" LOG_NAME "] Error while configuring CoAP to use DTLS-RPK.");
-			goto error;
-		}
+        if (!coap_context_set_pki(coap_context, &dtls_pki)) {
+            charra_log_error("[" LOG_NAME
+                             "] Error while configuring CoAP to use DTLS-RPK.");
+            goto error;
+        }
 
-		if ((coap_endpoint = charra_coap_new_endpoint(coap_context,
-				 LISTEN_ADDRESS, port, COAP_PROTO_DTLS)) == NULL) {
-			charra_log_error(
-				"[" LOG_NAME
-				"] Cannot create CoAP server endpoint based on DTLS-RPK.\n");
-			goto error;
-		}
-	} else {
-		charra_log_info(
-			"[" LOG_NAME "] Creating CoAP server endpoint using UDP.");
-		if ((coap_endpoint = charra_coap_new_endpoint(
-				 coap_context, LISTEN_ADDRESS, port, COAP_PROTO_UDP)) == NULL) {
-			charra_log_error(
-				"[" LOG_NAME
-				"] Cannot create CoAP server endpoint based on UDP.\n");
-			goto error;
-		}
-	}
+        if ((coap_endpoint = charra_coap_new_endpoint(coap_context,
+                     LISTEN_ADDRESS, port, COAP_PROTO_DTLS)) == NULL) {
+            charra_log_error("[" LOG_NAME "] Cannot create CoAP server "
+                             "endpoint based on DTLS-RPK.\n");
+            goto error;
+        }
+    } else {
+        charra_log_info(
+                "[" LOG_NAME "] Creating CoAP server endpoint using UDP.");
+        if ((coap_endpoint = charra_coap_new_endpoint(coap_context,
+                     LISTEN_ADDRESS, port, COAP_PROTO_UDP)) == NULL) {
+            charra_log_error(
+                    "[" LOG_NAME
+                    "] Cannot create CoAP server endpoint based on UDP.\n");
+            goto error;
+        }
+    }
 
-	/* register CoAP resource and resource handler */
-	charra_log_info("[" LOG_NAME "] Registering CoAP resources.");
-	charra_coap_add_resource(
-		coap_context, COAP_REQUEST_FETCH, "attest", coap_attest_handler);
+    /* register CoAP resource and resource handler */
+    charra_log_info("[" LOG_NAME "] Registering CoAP resources.");
+    charra_coap_add_resource(
+            coap_context, COAP_REQUEST_FETCH, "attest", coap_attest_handler);
 
-	/* enter main loop */
-	charra_log_debug("[" LOG_NAME "] Entering main loop.");
-	while (!quit) {
-		/* process CoAP I/O */
-		if (coap_io_process(coap_context, COAP_IO_WAIT) == -1) {
-			charra_log_error(
-				"[" LOG_NAME "] Error during CoAP I/O processing.");
-			goto error;
-		}
-	}
+    /* enter main loop */
+    charra_log_debug("[" LOG_NAME "] Entering main loop.");
+    while (!quit) {
+        /* process CoAP I/O */
+        if (coap_io_process(coap_context, COAP_IO_WAIT) == -1) {
+            charra_log_error(
+                    "[" LOG_NAME "] Error during CoAP I/O processing.");
+            goto error;
+        }
+    }
 
-	result = EXIT_SUCCESS;
-	goto finish;
+    result = EXIT_SUCCESS;
+    goto finish;
 
 error:
-	result = EXIT_FAILURE;
+    result = EXIT_FAILURE;
 
 finish:
-	/* free CoAP memory */
-	charra_free_and_null_ex(coap_endpoint, coap_free_endpoint);
-	charra_free_and_null_ex(coap_context, coap_free_context);
-	coap_cleanup();
+    /* free CoAP memory */
+    charra_free_and_null_ex(coap_endpoint, coap_free_endpoint);
+    charra_free_and_null_ex(coap_context, coap_free_context);
+    coap_cleanup();
 
-	return result;
+    return result;
 }
 
 /* --- function definitions ----------------------------------------------- */
@@ -280,208 +277,209 @@ finish:
 static void handle_sigint(int signum CHARRA_UNUSED) { quit = true; }
 
 static void release_data(
-	struct coap_session_t* session CHARRA_UNUSED, void* app_ptr) {
-	charra_free_and_null(app_ptr);
+        struct coap_session_t* session CHARRA_UNUSED, void* app_ptr) {
+    charra_free_and_null(app_ptr);
 }
 
 static void coap_attest_handler(struct coap_context_t* ctx CHARRA_UNUSED,
-	struct coap_resource_t* resource, struct coap_session_t* session,
-	struct coap_pdu_t* in, struct coap_binary_t* token,
-	struct coap_string_t* query, struct coap_pdu_t* out) {
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
-	int coap_r = 0;
-	TSS2_RC tss_r = 0;
-	ESYS_TR sig_key_handle = ESYS_TR_NONE;
-	TPM2B_PUBLIC* public_key = NULL;
+        struct coap_resource_t* resource, struct coap_session_t* session,
+        struct coap_pdu_t* in, struct coap_binary_t* token,
+        struct coap_string_t* query, struct coap_pdu_t* out) {
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    int coap_r = 0;
+    TSS2_RC tss_r = 0;
+    ESYS_TR sig_key_handle = ESYS_TR_NONE;
+    TPM2B_PUBLIC* public_key = NULL;
 
-	/* --- receive incoming data --- */
+    /* --- receive incoming data --- */
 
-	charra_log_info(
-		"[" LOG_NAME "] Resource '%s': Received message.", "attest");
-	coap_show_pdu(LOG_DEBUG, in);
+    charra_log_info(
+            "[" LOG_NAME "] Resource '%s': Received message.", "attest");
+    coap_show_pdu(LOG_DEBUG, in);
 
-	/* get data */
-	size_t data_len = 0;
-	const uint8_t* data = NULL;
-	size_t data_offset = 0;
-	size_t data_total_len = 0;
-	if ((coap_r = coap_get_data_large(
-			 in, &data_len, &data, &data_offset, &data_total_len)) == 0) {
-		charra_log_error("[" LOG_NAME "] Could not get CoAP PDU data.");
-		goto error;
-	} else {
-		charra_log_info(
-			"[" LOG_NAME "] Received data of length %zu.", data_len);
-		charra_log_info("[" LOG_NAME "] Received data of total length %zu.",
-			data_total_len);
-	}
+    /* get data */
+    size_t data_len = 0;
+    const uint8_t* data = NULL;
+    size_t data_offset = 0;
+    size_t data_total_len = 0;
+    if ((coap_r = coap_get_data_large(
+                 in, &data_len, &data, &data_offset, &data_total_len)) == 0) {
+        charra_log_error("[" LOG_NAME "] Could not get CoAP PDU data.");
+        goto error;
+    } else {
+        charra_log_info(
+                "[" LOG_NAME "] Received data of length %zu.", data_len);
+        charra_log_info("[" LOG_NAME "] Received data of total length %zu.",
+                data_total_len);
+    }
 
-	/* unmarshal data */
-	charra_log_info("[" LOG_NAME "] Parsing received CBOR data.");
-	msg_attestation_request_dto req = {0};
-	if ((charra_r = charra_unmarshal_attestation_request(
-			 data_len, data, &req)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Could not parse CBOR data.");
-		goto error;
-	}
+    /* unmarshal data */
+    charra_log_info("[" LOG_NAME "] Parsing received CBOR data.");
+    msg_attestation_request_dto req = {0};
+    if ((charra_r = charra_unmarshal_attestation_request(
+                 data_len, data, &req)) != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Could not parse CBOR data.");
+        goto error;
+    }
 
-	/* --- TPM quote --- */
+    /* --- TPM quote --- */
 
-	charra_log_info("[" LOG_NAME "] Preparing TPM quote data.");
+    charra_log_info("[" LOG_NAME "] Preparing TPM quote data.");
 
-	/* nonce */
-	if (req.nonce_len > sizeof(TPMU_HA)) {
-		charra_log_error("[" LOG_NAME "] Nonce too long.");
-		goto error;
-	}
-	TPM2B_DATA qualifying_data = {.size = 0, .buffer = {0}};
-	qualifying_data.size = req.nonce_len;
-	memcpy(qualifying_data.buffer, req.nonce, req.nonce_len);
+    /* nonce */
+    if (req.nonce_len > sizeof(TPMU_HA)) {
+        charra_log_error("[" LOG_NAME "] Nonce too long.");
+        goto error;
+    }
+    TPM2B_DATA qualifying_data = {.size = 0, .buffer = {0}};
+    qualifying_data.size = req.nonce_len;
+    memcpy(qualifying_data.buffer, req.nonce, req.nonce_len);
 
-	charra_log_info("Received nonce of length %d:", req.nonce_len);
-	charra_print_hex(CHARRA_LOG_INFO, req.nonce_len, req.nonce,
-		"                                   0x", "\n", false);
+    charra_log_info("Received nonce of length %d:", req.nonce_len);
+    charra_print_hex(CHARRA_LOG_INFO, req.nonce_len, req.nonce,
+            "                                   0x", "\n", false);
 
-	/* PCR selection */
-	TPML_PCR_SELECTION pcr_selection = {0};
-	if ((charra_r = charra_pcr_selections_to_tpm_pcr_selections(
-			 req.pcr_selections_len, req.pcr_selections, &pcr_selection)) !=
-		CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] PCR selection conversion error.");
-		goto error;
-	}
+    /* PCR selection */
+    TPML_PCR_SELECTION pcr_selection = {0};
+    if ((charra_r = charra_pcr_selections_to_tpm_pcr_selections(
+                 req.pcr_selections_len, req.pcr_selections, &pcr_selection)) !=
+            CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] PCR selection conversion error.");
+        goto error;
+    }
 
-	/* initialize ESAPI */
-	ESYS_CONTEXT* esys_ctx = NULL;
-	TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
-	if ((tss_r = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
-		TSS2_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Tss2_TctiLdr_Initialize.");
-		goto error;
-	}
-	if ((tss_r = Esys_Initialize(&esys_ctx, tcti_ctx, NULL)) !=
-		TSS2_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Esys_Initialize.");
-		goto error;
-	}
+    /* initialize ESAPI */
+    ESYS_CONTEXT* esys_ctx = NULL;
+    TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
+    if ((tss_r = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
+            TSS2_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Tss2_TctiLdr_Initialize.");
+        goto error;
+    }
+    if ((tss_r = Esys_Initialize(&esys_ctx, tcti_ctx, NULL)) !=
+            TSS2_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Esys_Initialize.");
+        goto error;
+    }
 
-	/* load TPM key */
-	charra_log_info("[" LOG_NAME "] Loading TPM key.");
-	if ((charra_r = charra_load_tpm2_key(esys_ctx, req.sig_key_id_len,
-			 req.sig_key_id, &sig_key_handle, &public_key)) !=
-		CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Could not load TPM key.");
-		goto error;
-	}
+    /* load TPM key */
+    charra_log_info("[" LOG_NAME "] Loading TPM key.");
+    if ((charra_r = charra_load_tpm2_key(esys_ctx, req.sig_key_id_len,
+                 req.sig_key_id, &sig_key_handle, &public_key)) !=
+            CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Could not load TPM key.");
+        goto error;
+    }
 
-	/* do the TPM quote */
-	charra_log_info("[" LOG_NAME "] Do TPM Quote.");
-	TPM2B_ATTEST* attest_buf = NULL;
-	TPMT_SIGNATURE* signature = NULL;
-	if ((tss_r = tpm2_quote(esys_ctx, sig_key_handle, &pcr_selection,
-			 &qualifying_data, &attest_buf, &signature)) != TSS2_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] TPM2 quote.");
-		goto error;
-	} else {
-		charra_log_info("[" LOG_NAME "] TPM Quote successful.");
-	}
+    /* do the TPM quote */
+    charra_log_info("[" LOG_NAME "] Do TPM Quote.");
+    TPM2B_ATTEST* attest_buf = NULL;
+    TPMT_SIGNATURE* signature = NULL;
+    if ((tss_r = tpm2_quote(esys_ctx, sig_key_handle, &pcr_selection,
+                 &qualifying_data, &attest_buf, &signature)) !=
+            TSS2_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] TPM2 quote.");
+        goto error;
+    } else {
+        charra_log_info("[" LOG_NAME "] TPM Quote successful.");
+    }
 
-	/* --- send response data --- */
+    /* --- send response data --- */
 
-	/* read IMA event log if requested */
-	uint8_t* ima_event_log = NULL;
-	size_t ima_event_log_len = 0;
-	if (req.event_log_path_len != 0) {
-		charra_log_info("[" LOG_NAME "] Reading IMA event log.");
-		char* path = malloc(sizeof(char) * (req.event_log_path_len + 1));
-		memcpy(path, req.event_log_path, req.event_log_path_len);
-		path[req.event_log_path_len + 1] = '\n';
-		CHARRA_RC rc = charra_io_read_continuous_binary_file(
-			path, &ima_event_log, &ima_event_log_len);
-		if (rc != CHARRA_RC_SUCCESS) {
-			charra_log_error("[" LOG_NAME "] Error while reading IMA event "
-							 "log. Sending empty event log!");
-			ima_event_log_len = 0;
-			ima_event_log = NULL;
-		} else {
-			charra_log_info("[" LOG_NAME
-							"] IMA event log has a size of %d bytes.",
-				ima_event_log_len);
-		}
-	}
+    /* read IMA event log if requested */
+    uint8_t* ima_event_log = NULL;
+    size_t ima_event_log_len = 0;
+    if (req.event_log_path_len != 0) {
+        charra_log_info("[" LOG_NAME "] Reading IMA event log.");
+        char* path = malloc(sizeof(char) * (req.event_log_path_len + 1));
+        memcpy(path, req.event_log_path, req.event_log_path_len);
+        path[req.event_log_path_len + 1] = '\n';
+        CHARRA_RC rc = charra_io_read_continuous_binary_file(
+                path, &ima_event_log, &ima_event_log_len);
+        if (rc != CHARRA_RC_SUCCESS) {
+            charra_log_error("[" LOG_NAME "] Error while reading IMA event "
+                             "log. Sending empty event log!");
+            ima_event_log_len = 0;
+            ima_event_log = NULL;
+        } else {
+            charra_log_info("[" LOG_NAME
+                            "] IMA event log has a size of %d bytes.",
+                    ima_event_log_len);
+        }
+    }
 
-	/* prepare response */
-	charra_log_info("[" LOG_NAME "] Preparing response.");
+    /* prepare response */
+    charra_log_info("[" LOG_NAME "] Preparing response.");
 
-	/* prepare response DTO */
-	msg_attestation_response_dto res = {
-		.attestation_data_len = attest_buf->size,
-		.attestation_data = {0}, // must be memcpy'd, see below
-		.tpm2_signature_len = sizeof(*signature),
-		.tpm2_signature = {0}, // must be memcpy'd, see below
-		.tpm2_public_key_len = sizeof(*public_key),
-		.tpm2_public_key = {0}, // must be memcpy'd, see below
-		.event_log_len = ima_event_log_len,
-		.event_log = ima_event_log,
-	};
-	memcpy(res.attestation_data, attest_buf->attestationData,
-		res.attestation_data_len);
-	memcpy(res.tpm2_signature, signature, res.tpm2_signature_len);
-	memcpy(res.tpm2_public_key, public_key, res.tpm2_public_key_len);
+    /* prepare response DTO */
+    msg_attestation_response_dto res = {
+            .attestation_data_len = attest_buf->size,
+            .attestation_data = {0},  // must be memcpy'd, see below
+            .tpm2_signature_len = sizeof(*signature),
+            .tpm2_signature = {0},  // must be memcpy'd, see below
+            .tpm2_public_key_len = sizeof(*public_key),
+            .tpm2_public_key = {0},  // must be memcpy'd, see below
+            .event_log_len = ima_event_log_len,
+            .event_log = ima_event_log,
+    };
+    memcpy(res.attestation_data, attest_buf->attestationData,
+            res.attestation_data_len);
+    memcpy(res.tpm2_signature, signature, res.tpm2_signature_len);
+    memcpy(res.tpm2_public_key, public_key, res.tpm2_public_key_len);
 
-	/* clean up */
-	charra_free_and_null(signature);
-	charra_free_and_null(attest_buf);
-	charra_free_and_null(public_key);
+    /* clean up */
+    charra_free_and_null(signature);
+    charra_free_and_null(attest_buf);
+    charra_free_and_null(public_key);
 
-	/* marshal response */
-	charra_log_info("[" LOG_NAME "] Marshaling response to CBOR.");
-	uint32_t res_buf_len = 0;
-	uint8_t* res_buf = NULL;
-	if ((charra_r = charra_marshal_attestation_response(
-			 &res, &res_buf_len, &res_buf)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Error marshaling data.");
-		goto error;
-	}
-	charra_log_info(
-		"[" LOG_NAME "] Size of marshaled response is %d bytes.", res_buf_len);
+    /* marshal response */
+    charra_log_info("[" LOG_NAME "] Marshaling response to CBOR.");
+    uint32_t res_buf_len = 0;
+    uint8_t* res_buf = NULL;
+    if ((charra_r = charra_marshal_attestation_response(
+                 &res, &res_buf_len, &res_buf)) != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Error marshaling data.");
+        goto error;
+    }
+    charra_log_info("[" LOG_NAME "] Size of marshaled response is %d bytes.",
+            res_buf_len);
 
-	// TODO in case an error above occurred, a error respone should be sent
-	// TODO the Verifier should be able to handle this error reponse
+    // TODO(any) In case an error occurred, an error respone should be sent.
+    // TODO(any): The verifier should be able to handle this error reponse.
 
-	/* add response data to outgoing PDU and send it */
-	charra_log_info(
-		"[" LOG_NAME
-		"] Adding marshaled data to CoAP response PDU and send it.");
-	out->code = COAP_RESPONSE_CODE_CONTENT;
-	if ((coap_r = coap_add_data_large_response(resource, session, in, out,
-			 token, query, COAP_MEDIATYPE_APPLICATION_CBOR, -1, 0, res_buf_len,
-			 res_buf, release_data, res_buf)) == 0) {
-		charra_log_error(
-			"[" LOG_NAME "] Error invoking coap_add_data_large_response().");
-		goto error;
-	}
+    /* add response data to outgoing PDU and send it */
+    charra_log_info(
+            "[" LOG_NAME
+            "] Adding marshaled data to CoAP response PDU and send it.");
+    out->code = COAP_RESPONSE_CODE_CONTENT;
+    if ((coap_r = coap_add_data_large_response(resource, session, in, out,
+                 token, query, COAP_MEDIATYPE_APPLICATION_CBOR, -1, 0,
+                 res_buf_len, res_buf, release_data, res_buf)) == 0) {
+        charra_log_error("[" LOG_NAME
+                         "] Error invoking coap_add_data_large_response().");
+        goto error;
+    }
 
 error:
-	/* Free heap objects */
-	charra_free_if_not_null(signature);
-	charra_free_if_not_null(attest_buf);
-	charra_free_if_not_null(public_key);
-	charra_io_free_continuous_file_buffer(&ima_event_log);
+    /* free heap objects */
+    charra_free_if_not_null(signature);
+    charra_free_if_not_null(attest_buf);
+    charra_free_if_not_null(public_key);
+    charra_io_free_continuous_file_buffer(&ima_event_log);
 
-	/* flush handles */
-	if (sig_key_handle != ESYS_TR_NONE) {
-		if (Esys_FlushContext(esys_ctx, sig_key_handle) != TSS2_RC_SUCCESS) {
-			charra_log_error(
-				"[" LOG_NAME "] TSS cleanup sig_key_handle failed.");
-		}
-	}
+    /* flush handles */
+    if (sig_key_handle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_ctx, sig_key_handle) != TSS2_RC_SUCCESS) {
+            charra_log_error(
+                    "[" LOG_NAME "] TSS cleanup sig_key_handle failed.");
+        }
+    }
 
-	/* finalize ESAPI */
-	if (esys_ctx != NULL) {
-		Esys_Finalize(&esys_ctx);
-	}
-	if (tcti_ctx != NULL) {
-		Tss2_TctiLdr_Finalize(&tcti_ctx);
-	}
+    /* finalize ESAPI */
+    if (esys_ctx != NULL) {
+        Esys_Finalize(&esys_ctx);
+    }
+    if (tcti_ctx != NULL) {
+        Tss2_TctiLdr_Finalize(&tcti_ctx);
+    }
 }

--- a/src/common/charra_log.c
+++ b/src/common/charra_log.c
@@ -25,35 +25,35 @@
 #include <time.h>
 
 static struct {
-	void* udata;
-	charra_log_LockFn lock;
-	FILE* fp;
-	charra_log_t level;
-	int quiet;
+    void* udata;
+    charra_log_LockFn lock;
+    FILE* fp;
+    charra_log_t level;
+    int quiet;
 } L;
 
 static const char* const charra_level_names[6] = {[CHARRA_LOG_TRACE] = "TRACE",
-	[CHARRA_LOG_DEBUG] = "DEBUG",
-	[CHARRA_LOG_INFO] = "INFO",
-	[CHARRA_LOG_WARN] = "WARN",
-	[CHARRA_LOG_ERROR] = "ERROR",
-	[CHARRA_LOG_FATAL] = "FATAL"};
+        [CHARRA_LOG_DEBUG] = "DEBUG",
+        [CHARRA_LOG_INFO] = "INFO",
+        [CHARRA_LOG_WARN] = "WARN",
+        [CHARRA_LOG_ERROR] = "ERROR",
+        [CHARRA_LOG_FATAL] = "FATAL"};
 
 #ifndef CHARRA_LOG_DISABLE_COLOR
 static const char* charra_level_colors[] = {
-	"\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"};
+        "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"};
 #endif
 
 static void charra_log_lock(void) {
-	if (L.lock) {
-		L.lock(L.udata, 1);
-	}
+    if (L.lock) {
+        L.lock(L.udata, 1);
+    }
 }
 
 static void charra_log_unlock(void) {
-	if (L.lock) {
-		L.lock(L.udata, 0);
-	}
+    if (L.lock) {
+        L.lock(L.udata, 0);
+    }
 }
 
 void charra_log_set_udata(void* udata) { L.udata = udata; }
@@ -67,102 +67,103 @@ void charra_log_set_level(charra_log_t level) { L.level = level; }
 void charra_log_set_quiet(int enable) { L.quiet = enable ? 1 : 0; }
 
 void charra_log_log(
-	charra_log_t level, const char* file, int line, const char* fmt, ...) {
-	if (level < L.level) {
-		return;
-	}
+        charra_log_t level, const char* file, int line, const char* fmt, ...) {
+    if (level < L.level) {
+        return;
+    }
 
-	/* acquire lock */
-	charra_log_lock();
+    /* acquire lock */
+    charra_log_lock();
 
-	/* get current time */
-	time_t t = time(NULL);
-	struct tm* lt = localtime(&t);
+    /* get current time */
+    time_t t = time(NULL);
+    struct tm* lt = localtime(&t);
 
-	/* log to stderr */
-	if (!L.quiet) {
-		va_list args;
-		char buf[16];
-		buf[strftime(buf, sizeof(buf), "%H:%M:%S", lt)] = '\0';
+    /* log to stderr */
+    if (!L.quiet) {
+        va_list args;
+        char buf[16];
+        buf[strftime(buf, sizeof(buf), "%H:%M:%S", lt)] = '\0';
 #ifndef CHARRA_LOG_DISABLE_COLOR
-		fprintf(stderr, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ", buf,
-			charra_level_colors[level], charra_level_names[level], file, line);
+        fprintf(stderr, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ", buf,
+                charra_level_colors[level], charra_level_names[level], file,
+                line);
 #else
-		fprintf(stderr, "%s %-5s %s:%d: ", buf, charra_level_names[level], file,
-			line);
+        fprintf(stderr, "%s %-5s %s:%d: ", buf, charra_level_names[level], file,
+                line);
 #endif
-		va_start(args, fmt);
-		vfprintf(stderr, fmt, args);
-		va_end(args);
-		fprintf(stderr, "\n");
-		fflush(stderr);
-	}
+        va_start(args, fmt);
+        vfprintf(stderr, fmt, args);
+        va_end(args);
+        fprintf(stderr, "\n");
+        fflush(stderr);
+    }
 
-	/* log to file */
-	if (L.fp) {
-		va_list args;
-		char buf[32];
-		buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
-		fprintf(L.fp, "%s %-5s %s:%d: ", buf, charra_level_names[level], file,
-			line);
-		va_start(args, fmt);
-		vfprintf(L.fp, fmt, args);
-		va_end(args);
-		fprintf(L.fp, "\n");
-		fflush(L.fp);
-	}
+    /* log to file */
+    if (L.fp) {
+        va_list args;
+        char buf[32];
+        buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
+        fprintf(L.fp, "%s %-5s %s:%d: ", buf, charra_level_names[level], file,
+                line);
+        va_start(args, fmt);
+        vfprintf(L.fp, fmt, args);
+        va_end(args);
+        fprintf(L.fp, "\n");
+        fflush(L.fp);
+    }
 
-	/* release lock */
-	charra_log_unlock();
+    /* release lock */
+    charra_log_unlock();
 }
 
 void charra_log_log_raw(charra_log_t level, const char* fmt, ...) {
-	if (level < L.level) {
-		return;
-	}
+    if (level < L.level) {
+        return;
+    }
 
-	/* acquire lock */
-	charra_log_lock();
+    /* acquire lock */
+    charra_log_lock();
 
-	/* log to stderr */
-	if (!L.quiet) {
-		va_list args;
-		va_start(args, fmt);
-		vfprintf(stderr, fmt, args);
-		va_end(args);
-		fflush(stderr);
-	}
+    /* log to stderr */
+    if (!L.quiet) {
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(stderr, fmt, args);
+        va_end(args);
+        fflush(stderr);
+    }
 
-	/* log to file */
-	if (L.fp) {
-		va_list args;
-		va_start(args, fmt);
-		vfprintf(L.fp, fmt, args);
-		va_end(args);
-		fflush(L.fp);
-	}
+    /* log to file */
+    if (L.fp) {
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(L.fp, fmt, args);
+        va_end(args);
+        fflush(L.fp);
+    }
 
-	/* release lock */
-	charra_log_unlock();
+    /* release lock */
+    charra_log_unlock();
 }
 
 int charra_log_level_from_str(
-	const char* log_level_str, charra_log_t* log_level) {
-	if (log_level_str != NULL) {
-		int array_size =
-			sizeof(charra_level_names) / sizeof(charra_level_names[0]);
-		for (int i = 0; i < array_size; i++) {
-			const char* name = charra_level_names[i];
-			if (name == NULL) {
-				continue;
-			}
-			if (strcmp(name, log_level_str) == 0) {
-				*log_level = i;
-				return 0;
-			}
-		}
-		return -1;
-	}
+        const char* log_level_str, charra_log_t* log_level) {
+    if (log_level_str != NULL) {
+        int array_size =
+                sizeof(charra_level_names) / sizeof(charra_level_names[0]);
+        for (int i = 0; i < array_size; i++) {
+            const char* name = charra_level_names[i];
+            if (name == NULL) {
+                continue;
+            }
+            if (strcmp(name, log_level_str) == 0) {
+                *log_level = i;
+                return 0;
+            }
+        }
+        return -1;
+    }
 
-	return -1;
+    return -1;
 }

--- a/src/common/charra_log.h
+++ b/src/common/charra_log.h
@@ -28,40 +28,40 @@
 typedef void (*charra_log_LockFn)(void* udata, int lock);
 
 typedef enum charra_log_t {
-	CHARRA_LOG_TRACE = 0,
-	CHARRA_LOG_DEBUG = 1,
-	CHARRA_LOG_INFO = 2,
-	CHARRA_LOG_WARN = 3,
-	CHARRA_LOG_ERROR = 4,
-	CHARRA_LOG_FATAL = 5,
+    CHARRA_LOG_TRACE = 0,
+    CHARRA_LOG_DEBUG = 1,
+    CHARRA_LOG_INFO = 2,
+    CHARRA_LOG_WARN = 3,
+    CHARRA_LOG_ERROR = 4,
+    CHARRA_LOG_FATAL = 5,
 } charra_log_t;
 
 #if (!CHARRA_LOG_DISABLE)
 #define charra_log_trace(...)                                                  \
-	charra_log_log(CHARRA_LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+    charra_log_log(CHARRA_LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
 #define charra_log_debug(...)                                                  \
-	charra_log_log(CHARRA_LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+    charra_log_log(CHARRA_LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #define charra_log_info(...)                                                   \
-	charra_log_log(CHARRA_LOG_INFO, __FILE__, __LINE__, __VA_ARGS__)
+    charra_log_log(CHARRA_LOG_INFO, __FILE__, __LINE__, __VA_ARGS__)
 #define charra_log_warn(...)                                                   \
-	charra_log_log(CHARRA_LOG_WARN, __FILE__, __LINE__, __VA_ARGS__)
+    charra_log_log(CHARRA_LOG_WARN, __FILE__, __LINE__, __VA_ARGS__)
 #define charra_log_error(...)                                                  \
-	charra_log_log(CHARRA_LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+    charra_log_log(CHARRA_LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 #define charra_log_fatal(...)                                                  \
-	charra_log_log(CHARRA_LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+    charra_log_log(CHARRA_LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
 #else
 #define charra_log_trace(...)                                                  \
-	{ ; }
+    { ; }
 #define charra_log_debug(...)                                                  \
-	{ ; }
+    { ; }
 #define charra_log_info(...)                                                   \
-	{ ; }
+    { ; }
 #define charra_log_warn(...)                                                   \
-	{ ; }
+    { ; }
 #define charra_log_error(...)                                                  \
-	{ ; }
+    { ; }
 #define charra_log_fatal(...)                                                  \
-	{ ; }
+    { ; }
 #endif
 
 void charra_log_set_udata(void* udata);
@@ -71,7 +71,7 @@ void charra_log_set_level(charra_log_t level);
 void charra_log_set_quiet(int enable);
 
 void charra_log_log(
-	charra_log_t level, const char* file, int line, const char* fmt, ...);
+        charra_log_t level, const char* file, int line, const char* fmt, ...);
 
 /**
  * @brief the same as charra_log_log(), but does not append filename, timestamp
@@ -89,6 +89,6 @@ void charra_log_log_raw(charra_log_t level, const char* fmt, ...);
  * @return 0 on success, -1 on error.
  */
 int charra_log_level_from_str(
-	const char* log_level_str, charra_log_t* log_level);
+        const char* log_level_str, charra_log_t* log_level);
 
 #endif /* CHARRA_LOG_H */

--- a/src/common/charra_macro.h
+++ b/src/common/charra_macro.h
@@ -24,22 +24,22 @@
 #include <stdlib.h>
 
 #define charra_free_and_null_ex(var, func_name)                                \
-	{                                                                          \
-		func_name(var);                                                        \
-		var = NULL;                                                            \
-	}
+    {                                                                          \
+        func_name(var);                                                        \
+        var = NULL;                                                            \
+    }
 
 #define charra_free_and_null(var)                                              \
-	{ charra_free_and_null_ex(var, free); }
+    { charra_free_and_null_ex(var, free); }
 
 #define charra_free_if_not_null_ex(var, func_name)                             \
-	{                                                                          \
-		if (var != NULL) {                                                     \
-			charra_free_and_null_ex(var, func_name);                           \
-		}                                                                      \
-	}
+    {                                                                          \
+        if (var != NULL) {                                                     \
+            charra_free_and_null_ex(var, func_name);                           \
+        }                                                                      \
+    }
 
 #define charra_free_if_not_null(var)                                           \
-	{ charra_free_if_not_null_ex(var, free); }
+    { charra_free_if_not_null_ex(var, free); }
 
 #endif /* CHARRA_MACRO_H */

--- a/src/core/charra_cvector.h
+++ b/src/core/charra_cvector.h
@@ -35,11 +35,11 @@
  * @return void
  */
 #define cvector_set_capacity(vec, size)                                        \
-	do {                                                                       \
-		if (vec) {                                                             \
-			((size_t*)(vec))[-1] = (size);                                     \
-		}                                                                      \
-	} while (0)
+    do {                                                                       \
+        if (vec) {                                                             \
+            ((size_t*)(vec))[-1] = (size);                                     \
+        }                                                                      \
+    } while (0)
 
 /**
  * @brief cvector_set_size - For internal use, sets the size variable of the
@@ -49,11 +49,11 @@
  * @return void
  */
 #define cvector_set_size(vec, size)                                            \
-	do {                                                                       \
-		if (vec) {                                                             \
-			((size_t*)(vec))[-2] = (size);                                     \
-		}                                                                      \
-	} while (0)
+    do {                                                                       \
+        if (vec) {                                                             \
+            ((size_t*)(vec))[-2] = (size);                                     \
+        }                                                                      \
+    } while (0)
 
 /**
  * @brief cvector_capacity - gets the current capacity of the vector
@@ -84,22 +84,22 @@
  * @return void
  */
 #define cvector_grow(vec, count)                                               \
-	do {                                                                       \
-		const size_t cv_sz = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2);  \
-		if (!(vec)) {                                                          \
-			size_t* cv_p = malloc(cv_sz);                                      \
-			assert(cv_p);                                                      \
-			(vec) = (void*)(&cv_p[2]);                                         \
-			cvector_set_capacity((vec), (count));                              \
-			cvector_set_size((vec), 0);                                        \
-		} else {                                                               \
-			size_t* cv_p1 = &((size_t*)(vec))[-2];                             \
-			size_t* cv_p2 = realloc(cv_p1, (cv_sz));                           \
-			assert(cv_p2);                                                     \
-			(vec) = (void*)(&cv_p2[2]);                                        \
-			cvector_set_capacity((vec), (count));                              \
-		}                                                                      \
-	} while (0)
+    do {                                                                       \
+        const size_t cv_sz = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2);  \
+        if (!(vec)) {                                                          \
+            size_t* cv_p = malloc(cv_sz);                                      \
+            assert(cv_p);                                                      \
+            (vec) = (void*)(&cv_p[2]);                                         \
+            cvector_set_capacity((vec), (count));                              \
+            cvector_set_size((vec), 0);                                        \
+        } else {                                                               \
+            size_t* cv_p1 = &((size_t*)(vec))[-2];                             \
+            size_t* cv_p2 = realloc(cv_p1, (cv_sz));                           \
+            assert(cv_p2);                                                     \
+            (vec) = (void*)(&cv_p2[2]);                                        \
+            cvector_set_capacity((vec), (count));                              \
+        }                                                                      \
+    } while (0)
 
 /**
  * @brief cvector_pop_back - removes the last element from the vector
@@ -107,9 +107,9 @@
  * @return void
  */
 #define cvector_pop_back(vec)                                                  \
-	do {                                                                       \
-		cvector_set_size((vec), cvector_size(vec) - 1);                        \
-	} while (0)
+    do {                                                                       \
+        cvector_set_size((vec), cvector_size(vec) - 1);                        \
+    } while (0)
 
 /**
  * @brief cvector_erase - removes the element at index i from the vector
@@ -118,18 +118,18 @@
  * @return void
  */
 #define cvector_erase(vec, i)                                                  \
-	do {                                                                       \
-		if (vec) {                                                             \
-			const size_t cv_sz = cvector_size(vec);                            \
-			if ((i) < cv_sz) {                                                 \
-				cvector_set_size((vec), cv_sz - 1);                            \
-				size_t cv_x;                                                   \
-				for (cv_x = (i); cv_x < (cv_sz - 1); ++cv_x) {                 \
-					(vec)[cv_x] = (vec)[cv_x + 1];                             \
-				}                                                              \
-			}                                                                  \
-		}                                                                      \
-	} while (0)
+    do {                                                                       \
+        if (vec) {                                                             \
+            const size_t cv_sz = cvector_size(vec);                            \
+            if ((i) < cv_sz) {                                                 \
+                cvector_set_size((vec), cv_sz - 1);                            \
+                size_t cv_x;                                                   \
+                for (cv_x = (i); cv_x < (cv_sz - 1); ++cv_x) {                 \
+                    (vec)[cv_x] = (vec)[cv_x + 1];                             \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+    } while (0)
 
 /**
  * @brief cvector_free - frees all memory associated with the vector
@@ -137,12 +137,12 @@
  * @return void
  */
 #define cvector_free(vec)                                                      \
-	do {                                                                       \
-		if (vec) {                                                             \
-			size_t* p1 = &((size_t*)(vec))[-2];                                \
-			free(p1);                                                          \
-		}                                                                      \
-	} while (0)
+    do {                                                                       \
+        if (vec) {                                                             \
+            size_t* p1 = &((size_t*)(vec))[-2];                                \
+            free(p1);                                                          \
+        }                                                                      \
+    } while (0)
 
 /**
  * @brief cvector_begin - returns an iterator to first element of the vector
@@ -169,14 +169,14 @@
  * @return void
  */
 #define cvector_push_back(vec, value)                                          \
-	do {                                                                       \
-		size_t cv_cap = cvector_capacity(vec);                                 \
-		if (cv_cap <= cvector_size(vec)) {                                     \
-			cvector_grow((vec), !cv_cap ? cv_cap + 1 : cv_cap * 2);            \
-		}                                                                      \
-		vec[cvector_size(vec)] = (value);                                      \
-		cvector_set_size((vec), cvector_size(vec) + 1);                        \
-	} while (0)
+    do {                                                                       \
+        size_t cv_cap = cvector_capacity(vec);                                 \
+        if (cv_cap <= cvector_size(vec)) {                                     \
+            cvector_grow((vec), !cv_cap ? cv_cap + 1 : cv_cap * 2);            \
+        }                                                                      \
+        vec[cvector_size(vec)] = (value);                                      \
+        cvector_set_size((vec), cvector_size(vec) + 1);                        \
+    } while (0)
 
 #else
 
@@ -187,14 +187,14 @@
  * @return void
  */
 #define cvector_push_back(vec, value)                                          \
-	do {                                                                       \
-		size_t cv_cap = cvector_capacity(vec);                                 \
-		if (cv_cap <= cvector_size(vec)) {                                     \
-			cvector_grow((vec), cv_cap + 1);                                   \
-		}                                                                      \
-		vec[cvector_size(vec)] = (value);                                      \
-		cvector_set_size((vec), cvector_size(vec) + 1);                        \
-	} while (0)
+    do {                                                                       \
+        size_t cv_cap = cvector_capacity(vec);                                 \
+        if (cv_cap <= cvector_size(vec)) {                                     \
+            cvector_grow((vec), cv_cap + 1);                                   \
+        }                                                                      \
+        vec[cvector_size(vec)] = (value);                                      \
+        cvector_set_size((vec), cvector_size(vec) + 1);                        \
+    } while (0)
 
 #endif /* CVECTOR_LOGARITHMIC_GROWTH */
 
@@ -205,10 +205,10 @@
  * @return void
  */
 #define cvector_copy(from, to)                                                 \
-	do {                                                                       \
-		for (size_t i = 0; i < cvector_size(from); i++) {                      \
-			cvector_push_back(to, from[i]);                                    \
-		}                                                                      \
-	} while (0)
+    do {                                                                       \
+        for (size_t i = 0; i < cvector_size(from); i++) {                      \
+            cvector_push_back(to, from[i]);                                    \
+        }                                                                      \
+    } while (0)
 
 #endif /* CVECTOR_H_ */

--- a/src/core/charra_dto.h
+++ b/src/core/charra_dto.h
@@ -31,70 +31,70 @@
 /* --- data transfer objects ---------------------------------------------- */
 
 typedef struct {
-	uint16_t tcg_hash_alg_id; // TPM2_ALG_ID
-	uint32_t pcrs_len;
-	uint8_t pcrs[TPM2_MAX_PCRS];
+    uint16_t tcg_hash_alg_id;  // TPM2_ALG_ID
+    uint32_t pcrs_len;
+    uint8_t pcrs[TPM2_MAX_PCRS];
 } pcr_selection_dto;
 
 typedef struct {
-	uint64_t clock;
-	uint32_t resetCounter;
-	uint32_t restartCounter;
-	bool safe;
+    uint64_t clock;
+    uint32_t resetCounter;
+    uint32_t restartCounter;
+    bool safe;
 } tpms_clock_info_dto;
 
 typedef struct {
-	uint16_t hash; // TPMI_ALG_HASH (TPM2_ALG_ID)
-	uint8_t sizeofSelect;
-	uint8_t pcrSelect[TPM2_PCR_SELECT_MAX];
+    uint16_t hash;  // TPMI_ALG_HASH (TPM2_ALG_ID)
+    uint8_t sizeofSelect;
+    uint8_t pcrSelect[TPM2_PCR_SELECT_MAX];
 } tpms_pcr_selection_dto;
 
 typedef struct {
-	uint32_t count;
-	tpms_pcr_selection_dto pcr_selections[TPM2_NUM_PCR_BANKS];
+    uint32_t count;
+    tpms_pcr_selection_dto pcr_selections[TPM2_NUM_PCR_BANKS];
 } tpml_pcr_selection_dto;
 
 typedef struct {
-	uint16_t size;
-	uint8_t buffer[sizeof(TPMU_HA)];
+    uint16_t size;
+    uint8_t buffer[sizeof(TPMU_HA)];
 } tpm2b_digest_dto;
 
 typedef struct {
-	tpml_pcr_selection_dto pcr_select; // TPML_PCR_SELECTION
-	tpm2b_digest_dto pcr_digest;	   // TPM2B_DIGEST
+    tpml_pcr_selection_dto pcr_select;  // TPML_PCR_SELECTION
+    tpm2b_digest_dto pcr_digest;        // TPM2B_DIGEST
 } tpms_quote_info_dto;
 
 typedef struct {
-	uint16_t qualified_signer; // TPM2B_NAME
-	tpms_clock_info_dto clock_info;
-	uint64_t firmware_version;
-	tpms_quote_info_dto quote;
+    uint16_t qualified_signer;  // TPM2B_NAME
+    tpms_clock_info_dto clock_info;
+    uint64_t firmware_version;
+    tpms_quote_info_dto quote;
 } tpms_attest_dto;
 
 /* --- messages ----------------------------------------------------------- */
 
 typedef struct {
-	bool hello;
-	size_t sig_key_id_len;
-	uint8_t sig_key_id[SIG_KEY_ID_MAXLEN];
-	size_t nonce_len;
-	uint8_t nonce[sizeof(TPMU_HA)];
-	uint32_t pcr_selections_len;
-	pcr_selection_dto pcr_selections[TPM2_NUM_PCR_BANKS];
-	uint32_t event_log_path_len;
-	uint8_t* event_log_path;
+    bool hello;
+    size_t sig_key_id_len;
+    uint8_t sig_key_id[SIG_KEY_ID_MAXLEN];
+    size_t nonce_len;
+    uint8_t nonce[sizeof(TPMU_HA)];
+    uint32_t pcr_selections_len;
+    pcr_selection_dto pcr_selections[TPM2_NUM_PCR_BANKS];
+    uint32_t event_log_path_len;
+    uint8_t* event_log_path;
 } msg_attestation_request_dto;
 
 typedef struct {
-	// TODO Use tpms_attest_dto attestation_data;
-	uint32_t attestation_data_len;
-	uint8_t attestation_data[sizeof(TPM2B_ATTEST)];
-	uint32_t tpm2_signature_len;
-	uint8_t tpm2_signature[sizeof(TPMT_SIGNATURE)];
-	uint32_t tpm2_public_key_len;
-	uint8_t tpm2_public_key[sizeof(TPM2B_PUBLIC)];
-	uint32_t event_log_len;
-	uint8_t* event_log;
+    // TODO Use tpms_attest_dto attestation_data;
+    uint32_t attestation_data_len;
+    uint8_t attestation_data[sizeof(TPM2B_ATTEST)];
+    uint32_t tpm2_signature_len;
+    uint8_t tpm2_signature[sizeof(TPMT_SIGNATURE)];
+    uint32_t tpm2_public_key_len;
+    uint8_t tpm2_public_key[sizeof(TPM2B_PUBLIC)];
+    uint32_t event_log_len;
+    uint8_t* event_log;
 } msg_attestation_response_dto;
 
 #endif /* CHARRA_DTO_H */

--- a/src/core/charra_helper.c
+++ b/src/core/charra_helper.c
@@ -29,81 +29,81 @@
 #include "charra_dto.h"
 
 CHARRA_RC charra_tpm2_pcr_selection_to_bitmap(const uint32_t pcr_selection_len,
-	const uint8_t pcr_selection[], TPMS_PCR_SELECTION* pcr_selection_bitmap) {
+        const uint8_t pcr_selection[],
+        TPMS_PCR_SELECTION* pcr_selection_bitmap) {
+    /* verify input parameters */
+    if (pcr_selection == NULL) {
+        charra_log_error(
+                "pcr_selection_to_bitmap(...): pcr_selection is NULL.\n");
+        return CHARRA_RC_BAD_ARGUMENT;
+    } else if (pcr_selection_len > (TPM2_MAX_PCRS - 8)) {
+        charra_log_error("pcr_selection_to_bitmap(...): pcr_selection_len "
+                         "(%i) greater than TPM2_MAX_PCRS - 8 (%i).\n",
+                pcr_selection_len, TPM2_MAX_PCRS - 8);
+        return CHARRA_RC_BAD_ARGUMENT;
+    }
 
-	/* verify input parameters */
-	if (pcr_selection == NULL) {
-		charra_log_error(
-			"pcr_selection_to_bitmap(...): pcr_selection is NULL.\n");
-		return CHARRA_RC_BAD_ARGUMENT;
-	} else if (pcr_selection_len > (TPM2_MAX_PCRS - 8)) {
-		charra_log_error("pcr_selection_to_bitmap(...): pcr_selection_len "
-						 "(%i) greater than TPM2_MAX_PCRS - 8 (%i).\n",
-			pcr_selection_len, TPM2_MAX_PCRS - 8);
-		return CHARRA_RC_BAD_ARGUMENT;
-	}
+    /* set length */
+    /* FIXME There seems to be a bug with sizes other than 3 */
+    pcr_selection_bitmap->sizeofSelect = TPM2_PCR_SELECT_MAX - 1;
 
-	/* set length */
-	/* FIXME There seems to be a bug with sizes other than 3 */
-	pcr_selection_bitmap->sizeofSelect = TPM2_PCR_SELECT_MAX - 1;
+    /* initialize PCR selection to all zeros */
+    for (uint32_t i = 0; i < pcr_selection_bitmap->sizeofSelect; ++i) {
+        pcr_selection_bitmap->pcrSelect[i] = 0;
+    }
 
-	/* initialize PCR selection to all zeros */
-	for (uint32_t i = 0; i < pcr_selection_bitmap->sizeofSelect; ++i) {
-		pcr_selection_bitmap->pcrSelect[i] = 0;
-	}
+    /* go through all selected PCRs */
+    for (uint32_t i = 0; i < pcr_selection_len; ++i) {
+        uint32_t pcr = pcr_selection[i];
 
-	/* go through all selected PCRs */
-	for (uint32_t i = 0; i < pcr_selection_len; ++i) {
-		uint32_t pcr = pcr_selection[i];
+        /* sanity check(s) */
+        if (pcr >= (TPM2_MAX_PCRS - 8)) {
+            charra_log_error("PCR index (%i) greater than TPM2_MAX_PCRS (%i).",
+                    pcr, TPM2_MAX_PCRS);
+        }
 
-		/* sanity check(s) */
-		if (pcr >= (TPM2_MAX_PCRS - 8)) {
-			charra_log_error("PCR index (%i) greater than TPM2_MAX_PCRS (%i).",
-				pcr, TPM2_MAX_PCRS);
-		}
+        /* set bit in PCR selection bitmap */
+        uint32_t selected_byte = (pcr / 8);
+        uint8_t selected_bit = 1 << (pcr % 8);
+        pcr_selection_bitmap->pcrSelect[selected_byte] |= selected_bit;
+    }
 
-		/* set bit in PCR selection bitmap */
-		uint32_t selected_byte = (pcr / 8);
-		uint8_t selected_bit = 1 << (pcr % 8);
-		pcr_selection_bitmap->pcrSelect[selected_byte] |= selected_bit;
-	}
-
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 }
 
 CHARRA_RC charra_pcr_selections_to_tpm_pcr_selections(
-	const uint32_t pcr_selection_list_len,
-	pcr_selection_dto* pcr_selection_list,
-	TPML_PCR_SELECTION* tpm_pcr_selections) {
-	CHARRA_RC err = CHARRA_RC_SUCCESS;
+        const uint32_t pcr_selection_list_len,
+        pcr_selection_dto* pcr_selection_list,
+        TPML_PCR_SELECTION* tpm_pcr_selections) {
+    CHARRA_RC err = CHARRA_RC_SUCCESS;
 
-	/* verify input */
-	if (tpm_pcr_selections == NULL) {
-		charra_log_error("NULL pointer: tpm_pcr_selections.",
-			pcr_selection_list_len, TPM2_NUM_PCR_BANKS);
-		return CHARRA_RC_BAD_ARGUMENT;
-	} else if (pcr_selection_list_len > TPM2_NUM_PCR_BANKS) {
-		charra_log_error("PCR selection length (%d) greater than allowed (%d).",
-			pcr_selection_list_len, TPM2_NUM_PCR_BANKS);
-		return CHARRA_RC_BAD_ARGUMENT;
-	}
+    /* verify input */
+    if (tpm_pcr_selections == NULL) {
+        charra_log_error("NULL pointer: tpm_pcr_selections.",
+                pcr_selection_list_len, TPM2_NUM_PCR_BANKS);
+        return CHARRA_RC_BAD_ARGUMENT;
+    } else if (pcr_selection_list_len > TPM2_NUM_PCR_BANKS) {
+        charra_log_error("PCR selection length (%d) greater than allowed (%d).",
+                pcr_selection_list_len, TPM2_NUM_PCR_BANKS);
+        return CHARRA_RC_BAD_ARGUMENT;
+    }
 
-	/* set length/count */
-	tpm_pcr_selections->count = pcr_selection_list_len;
+    /* set length/count */
+    tpm_pcr_selections->count = pcr_selection_list_len;
 
-	for (uint32_t i = 0; i < pcr_selection_list_len; ++i) {
-		/* set hash algo */
-		tpm_pcr_selections->pcrSelections[i].hash =
-			pcr_selection_list[i].tcg_hash_alg_id;
+    for (uint32_t i = 0; i < pcr_selection_list_len; ++i) {
+        /* set hash algo */
+        tpm_pcr_selections->pcrSelections[i].hash =
+                pcr_selection_list[i].tcg_hash_alg_id;
 
-		/* set PCR selection bitmap */
-		if ((err = charra_tpm2_pcr_selection_to_bitmap(
-				 pcr_selection_list[i].pcrs_len, pcr_selection_list[i].pcrs,
-				 &(tpm_pcr_selections->pcrSelections[i]))) !=
-			CHARRA_RC_SUCCESS) {
-			return err;
-		}
-	}
+        /* set PCR selection bitmap */
+        if ((err = charra_tpm2_pcr_selection_to_bitmap(
+                     pcr_selection_list[i].pcrs_len, pcr_selection_list[i].pcrs,
+                     &(tpm_pcr_selections->pcrSelections[i]))) !=
+                CHARRA_RC_SUCCESS) {
+            return err;
+        }
+    }
 
-	return err;
+    return err;
 }

--- a/src/core/charra_helper.h
+++ b/src/core/charra_helper.h
@@ -38,11 +38,12 @@
  * @return CHARRA_RC_BAD_ARGUMENT If input parameters are invalid.
  */
 CHARRA_RC charra_tpm2_pcr_selection_to_bitmap(const uint32_t pcr_selection_len,
-	const uint8_t pcr_selection[], TPMS_PCR_SELECTION* pcr_selection_bitmap);
+        const uint8_t pcr_selection[],
+        TPMS_PCR_SELECTION* pcr_selection_bitmap);
 
 CHARRA_RC charra_pcr_selections_to_tpm_pcr_selections(
-	const uint32_t pcr_selection_list_len,
-	pcr_selection_dto* pcr_selection_list,
-	TPML_PCR_SELECTION* tpm_pcr_selections);
+        const uint32_t pcr_selection_list_len,
+        pcr_selection_dto* pcr_selection_list,
+        TPML_PCR_SELECTION* tpm_pcr_selections);
 
 #endif /* CHARRA_HELPER_H */

--- a/src/core/charra_key_mgr.c
+++ b/src/core/charra_key_mgr.c
@@ -30,37 +30,37 @@
 #include "../util/tpm2_util.h"
 
 CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
-	const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	if (memcmp(key, "PK.RSA.default", key_len) == 0) {
-		charra_log_info("Loading key \"PK.RSA.default\".");
-		r = tpm2_create_primary_key_rsa2048(ctx, key_handle, out_public);
-		if (r != TSS2_RC_SUCCESS) {
-			charra_log_error("Loading of key \"PK.RSA.default\" failed.");
-			return CHARRA_RC_ERROR;
-		}
-	} else {
-		charra_log_error("TPM key not found.");
-		return CHARRA_RC_ERROR;
-	}
+        const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public) {
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    if (memcmp(key, "PK.RSA.default", key_len) == 0) {
+        charra_log_info("Loading key \"PK.RSA.default\".");
+        r = tpm2_create_primary_key_rsa2048(ctx, key_handle, out_public);
+        if (r != TSS2_RC_SUCCESS) {
+            charra_log_error("Loading of key \"PK.RSA.default\" failed.");
+            return CHARRA_RC_ERROR;
+        }
+    } else {
+        charra_log_error("TPM key not found.");
+        return CHARRA_RC_ERROR;
+    }
 
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 }
 
-CHARRA_RC charra_load_external_public_key(
-	ESYS_CONTEXT* ctx, TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	if (external_public_key == NULL) {
-		charra_log_error("External public key does not exist.");
-		return CHARRA_RC_ERROR;
-	}
+CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
+        TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle) {
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    if (external_public_key == NULL) {
+        charra_log_error("External public key does not exist.");
+        return CHARRA_RC_ERROR;
+    }
 
-	r = Esys_LoadExternal(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, NULL,
-		external_public_key, TPM2_RH_OWNER, key_handle);
-	if (r != TSS2_RC_SUCCESS) {
-		charra_log_error("Loading external public key failed.");
-		return CHARRA_RC_ERROR;
-	}
+    r = Esys_LoadExternal(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, NULL,
+            external_public_key, TPM2_RH_OWNER, key_handle);
+    if (r != TSS2_RC_SUCCESS) {
+        charra_log_error("Loading external public key failed.");
+        return CHARRA_RC_ERROR;
+    }
 
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 }

--- a/src/core/charra_key_mgr.h
+++ b/src/core/charra_key_mgr.h
@@ -28,9 +28,9 @@
 #include "../common/charra_error.h"
 
 CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
-	const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public);
+        const uint8_t* key, ESYS_TR* key_handle, TPM2B_PUBLIC** out_public);
 
-CHARRA_RC charra_load_external_public_key(
-	ESYS_CONTEXT* ctx, TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle);
+CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
+        TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle);
 
 #endif /* CHARRA_KEY_MGR_H */

--- a/src/core/charra_marshaling.c
+++ b/src/core/charra_marshaling.c
@@ -36,442 +36,443 @@
 #include "../util/tpm2_util.h"
 
 static CHARRA_RC charra_marshal_attestation_request_internal(
-	const msg_attestation_request_dto* attestation_request, UsefulBuf buf_in,
-	UsefulBufC* buf_out) {
-	charra_log_trace("<ENTER> %s()", __func__);
+        const msg_attestation_request_dto* attestation_request,
+        UsefulBuf buf_in, UsefulBufC* buf_out) {
+    charra_log_trace("<ENTER> %s()", __func__);
 
-	/* verify input */
-	assert(attestation_request != NULL);
-	assert(attestation_request->pcr_selections_len <= TPM2_NUM_PCR_BANKS);
-	assert(attestation_request->pcr_selections != NULL);
-	assert(attestation_request->pcr_selections->pcrs_len <= TPM2_MAX_PCRS);
-	assert(attestation_request->pcr_selections->pcrs != NULL);
-	assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
-	assert(attestation_request->nonce != NULL);
-	if (attestation_request->event_log_path_len != 0) {
-		assert(attestation_request->event_log_path != NULL);
-	}
+    /* verify input */
+    assert(attestation_request != NULL);
+    assert(attestation_request->pcr_selections_len <= TPM2_NUM_PCR_BANKS);
+    assert(attestation_request->pcr_selections != NULL);
+    assert(attestation_request->pcr_selections->pcrs_len <= TPM2_MAX_PCRS);
+    assert(attestation_request->pcr_selections->pcrs != NULL);
+    assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
+    assert(attestation_request->nonce != NULL);
+    if (attestation_request->event_log_path_len != 0) {
+        assert(attestation_request->event_log_path != NULL);
+    }
 
-	QCBOREncodeContext ec = {0};
+    QCBOREncodeContext ec = {0};
 
-	QCBOREncode_Init(&ec, buf_in);
+    QCBOREncode_Init(&ec, buf_in);
 
-	/* root array */
-	QCBOREncode_OpenArray(&ec);
+    /* root array */
+    QCBOREncode_OpenArray(&ec);
 
-	/* encode "hello" */
-	QCBOREncode_AddBool(&ec, attestation_request->hello);
+    /* encode "hello" */
+    QCBOREncode_AddBool(&ec, attestation_request->hello);
 
-	/* encode "key-id" */
-	UsefulBufC key_id = {
-		attestation_request->sig_key_id, attestation_request->sig_key_id_len};
-	QCBOREncode_AddBytes(&ec, key_id);
+    /* encode "key-id" */
+    UsefulBufC key_id = {attestation_request->sig_key_id,
+            attestation_request->sig_key_id_len};
+    QCBOREncode_AddBytes(&ec, key_id);
 
-	/* encode "nonce" */
-	UsefulBufC nonce = {
-		attestation_request->nonce, attestation_request->nonce_len};
-	QCBOREncode_AddBytes(&ec, nonce);
+    /* encode "nonce" */
+    UsefulBufC nonce = {
+            attestation_request->nonce, attestation_request->nonce_len};
+    QCBOREncode_AddBytes(&ec, nonce);
 
-	/* encode "pcr-selections" */
-	QCBOREncode_OpenArray(&ec);
-	for (uint32_t i = 0; i < attestation_request->pcr_selections_len; ++i) {
-		QCBOREncode_OpenArray(&ec);
-		QCBOREncode_AddInt64(
-			&ec, attestation_request->pcr_selections[i].tcg_hash_alg_id);
-		{
-			/* open array: pcrs_array_encoder */
-			QCBOREncode_OpenArray(&ec);
-			for (uint32_t j = 0;
-				 j < attestation_request->pcr_selections[i].pcrs_len; ++j) {
+    /* encode "pcr-selections" */
+    QCBOREncode_OpenArray(&ec);
+    for (uint32_t i = 0; i < attestation_request->pcr_selections_len; ++i) {
+        QCBOREncode_OpenArray(&ec);
+        QCBOREncode_AddInt64(
+                &ec, attestation_request->pcr_selections[i].tcg_hash_alg_id);
+        {
+            /* open array: pcrs_array_encoder */
+            QCBOREncode_OpenArray(&ec);
+            for (uint32_t j = 0;
+                    j < attestation_request->pcr_selections[i].pcrs_len; ++j) {
+                QCBOREncode_AddUInt64(
+                        &ec, attestation_request->pcr_selections[i].pcrs[j]);
+            }
+            /* close array: pcrs_array_encoder */
+            QCBOREncode_CloseArray(&ec);
+        }
+        /* close array: pcr_selection_array_encoder */
+        QCBOREncode_CloseArray(&ec);
+    }
 
-				QCBOREncode_AddUInt64(
-					&ec, attestation_request->pcr_selections[i].pcrs[j]);
-			}
-			/* close array: pcrs_array_encoder */
-			QCBOREncode_CloseArray(&ec);
-		}
-		/* close array: pcr_selection_array_encoder */
-		QCBOREncode_CloseArray(&ec);
-	}
+    /* close array: pcr_selections_array_encoder */
+    QCBOREncode_CloseArray(&ec);
 
-	/* close array: pcr_selections_array_encoder */
-	QCBOREncode_CloseArray(&ec);
+    /* encode "event_log_path" */
+    UsefulBufC event_log_path = {.ptr = attestation_request->event_log_path,
+            .len = attestation_request->event_log_path_len};
+    QCBOREncode_AddBytes(&ec, event_log_path);
 
-	/* encode "event_log_path" */
-	UsefulBufC event_log_path = {.ptr = attestation_request->event_log_path,
-		.len = attestation_request->event_log_path_len};
-	QCBOREncode_AddBytes(&ec, event_log_path);
+    /* close array: root_array_encoder */
+    QCBOREncode_CloseArray(&ec);
 
-	/* close array: root_array_encoder */
-	QCBOREncode_CloseArray(&ec);
-
-	if (QCBOREncode_Finish(&ec, buf_out) == QCBOR_SUCCESS) {
-		return CHARRA_RC_SUCCESS;
-	} else {
-		return CHARRA_RC_MARSHALING_ERROR;
-	}
+    if (QCBOREncode_Finish(&ec, buf_out) == QCBOR_SUCCESS) {
+        return CHARRA_RC_SUCCESS;
+    } else {
+        return CHARRA_RC_MARSHALING_ERROR;
+    }
 }
 
 CHARRA_RC charra_marshal_attestation_request_size(
-	const msg_attestation_request_dto* attestation_request,
-	size_t* marshaled_data_len) {
-	charra_log_trace("<ENTER> %s()", __func__);
+        const msg_attestation_request_dto* attestation_request,
+        size_t* marshaled_data_len) {
+    charra_log_trace("<ENTER> %s()", __func__);
 
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
 
-	/* passing this buffer instructs QCBOR to return only the size and do no
-	 * actual encoding */
-	UsefulBuf buf_in = {.len = SIZE_MAX, .ptr = NULL};
-	UsefulBufC buf_out = {0};
+    /* passing this buffer instructs QCBOR to return only the size and do no
+     * actual encoding */
+    UsefulBuf buf_in = {.len = SIZE_MAX, .ptr = NULL};
+    UsefulBufC buf_out = {0};
 
-	if ((charra_r = charra_marshal_attestation_request_internal(
-			 attestation_request, buf_in, &buf_out)) == CHARRA_RC_SUCCESS) {
-		*marshaled_data_len = buf_out.len;
-	}
+    if ((charra_r = charra_marshal_attestation_request_internal(
+                 attestation_request, buf_in, &buf_out)) == CHARRA_RC_SUCCESS) {
+        *marshaled_data_len = buf_out.len;
+    }
 
-	return charra_r;
+    return charra_r;
 }
 
 CHARRA_RC charra_marshal_attestation_request(
-	const msg_attestation_request_dto* attestation_request,
-	uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
-	charra_log_trace("<ENTER> %s()", __func__);
+        const msg_attestation_request_dto* attestation_request,
+        uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
+    charra_log_trace("<ENTER> %s()", __func__);
 
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
 
-	/* verify input */
-	assert(attestation_request != NULL);
-	assert(attestation_request->pcr_selections_len <= TPM2_NUM_PCR_BANKS);
-	assert(attestation_request->pcr_selections != NULL);
-	assert(attestation_request->pcr_selections->pcrs_len <= TPM2_MAX_PCRS);
-	assert(attestation_request->pcr_selections->pcrs != NULL);
-	assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
-	assert(attestation_request->nonce != NULL);
-	if (attestation_request->event_log_path_len != 0) {
-		assert(attestation_request->event_log_path != NULL);
-	}
+    /* verify input */
+    assert(attestation_request != NULL);
+    assert(attestation_request->pcr_selections_len <= TPM2_NUM_PCR_BANKS);
+    assert(attestation_request->pcr_selections != NULL);
+    assert(attestation_request->pcr_selections->pcrs_len <= TPM2_MAX_PCRS);
+    assert(attestation_request->pcr_selections->pcrs != NULL);
+    assert(attestation_request->nonce_len <= sizeof(TPMU_HA));
+    assert(attestation_request->nonce != NULL);
+    if (attestation_request->event_log_path_len != 0) {
+        assert(attestation_request->event_log_path != NULL);
+    }
 
-	/* compute size of marshaled data */
-	UsefulBuf buf_in = {.len = 0, .ptr = NULL};
-	if ((charra_r = charra_marshal_attestation_request_size(
-			 attestation_request, &(buf_in.len))) != CHARRA_RC_SUCCESS) {
-		charra_log_error("Could not compute size of marshaled data.");
-		return charra_r;
-	}
-	charra_log_debug("Size of marshaled data is %zu bytes.", buf_in.len);
+    /* compute size of marshaled data */
+    UsefulBuf buf_in = {.len = 0, .ptr = NULL};
+    if ((charra_r = charra_marshal_attestation_request_size(
+                 attestation_request, &(buf_in.len))) != CHARRA_RC_SUCCESS) {
+        charra_log_error("Could not compute size of marshaled data.");
+        return charra_r;
+    }
+    charra_log_debug("Size of marshaled data is %zu bytes.", buf_in.len);
 
-	/* allocate buffer size */
-	if ((buf_in.ptr = malloc(buf_in.len)) == NULL) {
-		charra_log_error("Allocating %zu bytes of memory failed.", buf_in.len);
-		return CHARRA_RC_MARSHALING_ERROR;
-	}
-	charra_log_debug("Allocated %zu bytes of memory.", buf_in.len);
+    /* allocate buffer size */
+    if ((buf_in.ptr = malloc(buf_in.len)) == NULL) {
+        charra_log_error("Allocating %zu bytes of memory failed.", buf_in.len);
+        return CHARRA_RC_MARSHALING_ERROR;
+    }
+    charra_log_debug("Allocated %zu bytes of memory.", buf_in.len);
 
-	/* encode */
-	UsefulBufC buf_out = {.len = 0, .ptr = NULL};
-	if ((charra_r = charra_marshal_attestation_request_internal(
-			 attestation_request, buf_in, &buf_out)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("Could not marshal data.");
-		return charra_r;
-	}
+    /* encode */
+    UsefulBufC buf_out = {.len = 0, .ptr = NULL};
+    if ((charra_r = charra_marshal_attestation_request_internal(
+                 attestation_request, buf_in, &buf_out)) != CHARRA_RC_SUCCESS) {
+        charra_log_error("Could not marshal data.");
+        return charra_r;
+    }
 
-	/* set output parameters */
-	*marshaled_data_len = buf_out.len;
-	*marshaled_data = (uint8_t*)buf_out.ptr;
+    /* set output parameters */
+    *marshaled_data_len = buf_out.len;
+    *marshaled_data = (uint8_t*)buf_out.ptr;
 
-	return charra_r;
+    return charra_r;
 }
 
 // TODO implement this function using QCBOREncode_* functions
 CHARRA_RC charra_unmarshal_attestation_request(
-	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
-	msg_attestation_request_dto* attestation_request) {
-	msg_attestation_request_dto req = {0};
+        const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
+        msg_attestation_request_dto* attestation_request) {
+    msg_attestation_request_dto req = {0};
 
-	QCBORError cborerr = QCBOR_SUCCESS;
-	UsefulBufC marshaled_data_buf = {marshaled_data, marshaled_data_len};
-	QCBORDecodeContext dc = {0};
-	QCBORItem item = {0};
+    QCBORError cborerr = QCBOR_SUCCESS;
+    UsefulBufC marshaled_data_buf = {marshaled_data, marshaled_data_len};
+    QCBORDecodeContext dc = {0};
+    QCBORItem item = {0};
 
-	QCBORDecode_Init(&dc, marshaled_data_buf, QCBOR_DECODE_MODE_NORMAL);
+    QCBORDecode_Init(&dc, marshaled_data_buf, QCBOR_DECODE_MODE_NORMAL);
 
-	if (charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY))
-		goto cbor_parse_error;
+    if (charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY))
+        goto cbor_parse_error;
 
-	/* parse "hello" (bool) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, CHARRA_CBOR_TYPE_BOOLEAN)))
-		goto cbor_parse_error;
-	req.hello = charra_cbor_get_bool_val(&item);
+    /* parse "hello" (bool) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, CHARRA_CBOR_TYPE_BOOLEAN)))
+        goto cbor_parse_error;
+    req.hello = charra_cbor_get_bool_val(&item);
 
-	/* parse "key-id" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	req.sig_key_id_len = item.val.string.len;
-	memcpy(&(req.sig_key_id), item.val.string.ptr, req.sig_key_id_len);
+    /* parse "key-id" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    req.sig_key_id_len = item.val.string.len;
+    memcpy(&(req.sig_key_id), item.val.string.ptr, req.sig_key_id_len);
 
-	/* parse "nonce" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	req.nonce_len = item.val.string.len;
-	memcpy(&(req.nonce), item.val.string.ptr, req.nonce_len);
+    /* parse "nonce" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    req.nonce_len = item.val.string.len;
+    memcpy(&(req.nonce), item.val.string.ptr, req.nonce_len);
 
-	/* parse array "pcr-selections" */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
-		goto cbor_parse_error;
+    /* parse array "pcr-selections" */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
+        goto cbor_parse_error;
 
-	/* initialize array and array length */
-	req.pcr_selections_len = (uint32_t)item.val.uCount;
+    /* initialize array and array length */
+    req.pcr_selections_len = (uint32_t)item.val.uCount;
 
-	/* go through all elements */
-	for (uint32_t i = 0; i < req.pcr_selections_len; ++i) {
-		/* parse array "pcr-selection" */
-		if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
-			goto cbor_parse_error;
+    /* go through all elements */
+    for (uint32_t i = 0; i < req.pcr_selections_len; ++i) {
+        /* parse array "pcr-selection" */
+        if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
+            goto cbor_parse_error;
 
-		/* parse "tcg-hash-alg-id" (UINT16) */
-		if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_INT64)))
-			goto cbor_parse_error;
-		req.pcr_selections[i].tcg_hash_alg_id = (uint16_t)item.val.uint64;
+        /* parse "tcg-hash-alg-id" (UINT16) */
+        if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_INT64)))
+            goto cbor_parse_error;
+        req.pcr_selections[i].tcg_hash_alg_id = (uint16_t)item.val.uint64;
 
-		/* parse array "pcrs" */
-		if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
-			goto cbor_parse_error;
+        /* parse array "pcrs" */
+        if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
+            goto cbor_parse_error;
 
-		/* initialize array and array length */
-		req.pcr_selections[i].pcrs_len = (uint32_t)item.val.uCount;
+        /* initialize array and array length */
+        req.pcr_selections[i].pcrs_len = (uint32_t)item.val.uCount;
 
-		/* go through all elements */
-		for (uint32_t j = 0; j < req.pcr_selections[i].pcrs_len; ++j) {
-			if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_INT64)))
-				goto cbor_parse_error;
-			req.pcr_selections[i].pcrs[j] = (uint8_t)item.val.uint64;
-		}
-	}
+        /* go through all elements */
+        for (uint32_t j = 0; j < req.pcr_selections[i].pcrs_len; ++j) {
+            if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_INT64)))
+                goto cbor_parse_error;
+            req.pcr_selections[i].pcrs[j] = (uint8_t)item.val.uint64;
+        }
+    }
 
-	/* parse "event-log-path" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	req.event_log_path_len = item.val.string.len;
-	if (req.event_log_path_len != 0) {
-		uint8_t* event_log_path = (uint8_t*)malloc(req.event_log_path_len);
-		if (event_log_path == NULL) {
-			goto cbor_parse_error;
-		} else {
-			req.event_log_path = event_log_path;
-			if (memcpy(req.event_log_path, item.val.string.ptr,
-					req.event_log_path_len) == NULL) {
-				goto cbor_parse_error;
-			}
-		}
-	}
+    /* parse "event-log-path" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    req.event_log_path_len = item.val.string.len;
+    if (req.event_log_path_len != 0) {
+        uint8_t* event_log_path = (uint8_t*)malloc(req.event_log_path_len);
+        if (event_log_path == NULL) {
+            goto cbor_parse_error;
+        } else {
+            req.event_log_path = event_log_path;
+            if (memcpy(req.event_log_path, item.val.string.ptr,
+                        req.event_log_path_len) == NULL) {
+                goto cbor_parse_error;
+            }
+        }
+    }
 
-	/* expect end of CBOR data */
-	if ((cborerr = QCBORDecode_Finish(&dc))) {
-		charra_log_error("CBOR parser: expected end of input, but could not "
-						 "find it. Continuing.");
-		goto cbor_parse_error;
-	}
+    /* expect end of CBOR data */
+    if ((cborerr = QCBORDecode_Finish(&dc))) {
+        charra_log_error("CBOR parser: expected end of input, but could not "
+                         "find it. Continuing.");
+        goto cbor_parse_error;
+    }
 
-	/* set output */
-	*attestation_request = req;
+    /* set output */
+    *attestation_request = req;
 
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 
 cbor_parse_error:
-	charra_log_error("CBOR parser: %s", qcbor_err_to_str(cborerr));
-	charra_log_info("CBOR parser: skipping parsing.");
+    charra_log_error("CBOR parser: %s", qcbor_err_to_str(cborerr));
+    charra_log_info("CBOR parser: skipping parsing.");
 
-	return CHARRA_RC_MARSHALING_ERROR;
+    return CHARRA_RC_MARSHALING_ERROR;
 }
 
 static CHARRA_RC charra_marshal_attestation_response_internal(
-	const msg_attestation_response_dto* attestation_response, UsefulBuf buf_in,
-	UsefulBufC* buf_out) {
-	charra_log_trace("<ENTER> %s()", __func__);
+        const msg_attestation_response_dto* attestation_response,
+        UsefulBuf buf_in, UsefulBufC* buf_out) {
+    charra_log_trace("<ENTER> %s()", __func__);
 
-	/* verify input */
-	assert(attestation_response != NULL);
-	assert(attestation_response->attestation_data != NULL);
-	assert(attestation_response->tpm2_signature != NULL);
-	assert(attestation_response->tpm2_public_key != NULL);
-	if (attestation_response->event_log_len != 0) {
-		assert(attestation_response->event_log != NULL);
-	}
+    /* verify input */
+    assert(attestation_response != NULL);
+    assert(attestation_response->attestation_data != NULL);
+    assert(attestation_response->tpm2_signature != NULL);
+    assert(attestation_response->tpm2_public_key != NULL);
+    if (attestation_response->event_log_len != 0) {
+        assert(attestation_response->event_log != NULL);
+    }
 
-	QCBOREncodeContext ec = {0};
+    QCBOREncodeContext ec = {0};
 
-	QCBOREncode_Init(&ec, buf_in);
+    QCBOREncode_Init(&ec, buf_in);
 
-	/* root array */
-	QCBOREncode_OpenArray(&ec);
+    /* root array */
+    QCBOREncode_OpenArray(&ec);
 
-	/* encode "attestation-data" */
-	UsefulBufC attestation_data = {
-		.ptr = attestation_response->attestation_data,
-		.len = attestation_response->attestation_data_len};
-	QCBOREncode_AddBytes(&ec, attestation_data);
+    /* encode "attestation-data" */
+    UsefulBufC attestation_data = {
+            .ptr = attestation_response->attestation_data,
+            .len = attestation_response->attestation_data_len};
+    QCBOREncode_AddBytes(&ec, attestation_data);
 
-	/* encode "tpm2-signature" */
-	UsefulBufC tpm2_signature = {.ptr = attestation_response->tpm2_signature,
-		.len = attestation_response->tpm2_signature_len};
-	QCBOREncode_AddBytes(&ec, tpm2_signature);
+    /* encode "tpm2-signature" */
+    UsefulBufC tpm2_signature = {.ptr = attestation_response->tpm2_signature,
+            .len = attestation_response->tpm2_signature_len};
+    QCBOREncode_AddBytes(&ec, tpm2_signature);
 
-	/* encode "tpm2-key-signature" */
-	UsefulBufC tpm2_public_key = {.ptr = attestation_response->tpm2_public_key,
-		.len = attestation_response->tpm2_public_key_len};
-	QCBOREncode_AddBytes(&ec, tpm2_public_key);
+    /* encode "tpm2-key-signature" */
+    UsefulBufC tpm2_public_key = {.ptr = attestation_response->tpm2_public_key,
+            .len = attestation_response->tpm2_public_key_len};
+    QCBOREncode_AddBytes(&ec, tpm2_public_key);
 
-	/* encode "event-log" */
-	UsefulBufC event_log = {.ptr = attestation_response->event_log,
-		.len = attestation_response->event_log_len};
-	QCBOREncode_AddBytes(&ec, event_log);
+    /* encode "event-log" */
+    UsefulBufC event_log = {.ptr = attestation_response->event_log,
+            .len = attestation_response->event_log_len};
+    QCBOREncode_AddBytes(&ec, event_log);
 
-	/* close array: root_array_encoder */
-	QCBOREncode_CloseArray(&ec);
+    /* close array: root_array_encoder */
+    QCBOREncode_CloseArray(&ec);
 
-	if (QCBOREncode_Finish(&ec, buf_out) == QCBOR_SUCCESS) {
-		return CHARRA_RC_SUCCESS;
-	} else {
-		return CHARRA_RC_MARSHALING_ERROR;
-	}
+    if (QCBOREncode_Finish(&ec, buf_out) == QCBOR_SUCCESS) {
+        return CHARRA_RC_SUCCESS;
+    } else {
+        return CHARRA_RC_MARSHALING_ERROR;
+    }
 }
 
 CHARRA_RC charra_marshal_attestation_response_size(
-	const msg_attestation_response_dto* attestation_response,
-	size_t* marshaled_data_len) {
-	charra_log_trace("<ENTER> %s()", __func__);
+        const msg_attestation_response_dto* attestation_response,
+        size_t* marshaled_data_len) {
+    charra_log_trace("<ENTER> %s()", __func__);
 
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
 
-	/* passing this buffer instructs QCBOR to return only the size and do no
-	 * actual encoding */
-	UsefulBuf buf_in = {.len = SIZE_MAX, .ptr = NULL};
-	UsefulBufC buf_out = {0};
+    /* passing this buffer instructs QCBOR to return only the size and do no
+     * actual encoding */
+    UsefulBuf buf_in = {.len = SIZE_MAX, .ptr = NULL};
+    UsefulBufC buf_out = {0};
 
-	if ((charra_r = charra_marshal_attestation_response_internal(
-			 attestation_response, buf_in, &buf_out)) == CHARRA_RC_SUCCESS) {
-		*marshaled_data_len = buf_out.len;
-	}
+    if ((charra_r = charra_marshal_attestation_response_internal(
+                 attestation_response, buf_in, &buf_out)) ==
+            CHARRA_RC_SUCCESS) {
+        *marshaled_data_len = buf_out.len;
+    }
 
-	return charra_r;
+    return charra_r;
 }
 
 CHARRA_RC charra_marshal_attestation_response(
-	const msg_attestation_response_dto* attestation_response,
-	uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
-	charra_log_trace("<ENTER> %s()", __func__);
+        const msg_attestation_response_dto* attestation_response,
+        uint32_t* marshaled_data_len, uint8_t** marshaled_data) {
+    charra_log_trace("<ENTER> %s()", __func__);
 
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
 
-	/* verify input */
-	assert(attestation_response != NULL);
-	assert(attestation_response->attestation_data != NULL);
-	assert(attestation_response->tpm2_signature != NULL);
-	assert(attestation_response->tpm2_public_key != NULL);
-	if (attestation_response->event_log_len != 0) {
-		assert(attestation_response->event_log != NULL);
-	}
+    /* verify input */
+    assert(attestation_response != NULL);
+    assert(attestation_response->attestation_data != NULL);
+    assert(attestation_response->tpm2_signature != NULL);
+    assert(attestation_response->tpm2_public_key != NULL);
+    if (attestation_response->event_log_len != 0) {
+        assert(attestation_response->event_log != NULL);
+    }
 
-	/* compute size of marshaled data */
-	UsefulBuf buf_in = {.len = 0, .ptr = NULL};
-	if ((charra_r = charra_marshal_attestation_response_size(
-			 attestation_response, &(buf_in.len))) != CHARRA_RC_SUCCESS) {
-		charra_log_error("Could not compute size of marshaled data.");
-		return charra_r;
-	}
-	charra_log_debug("Size of marshaled data is %zu bytes.", buf_in.len);
+    /* compute size of marshaled data */
+    UsefulBuf buf_in = {.len = 0, .ptr = NULL};
+    if ((charra_r = charra_marshal_attestation_response_size(
+                 attestation_response, &(buf_in.len))) != CHARRA_RC_SUCCESS) {
+        charra_log_error("Could not compute size of marshaled data.");
+        return charra_r;
+    }
+    charra_log_debug("Size of marshaled data is %zu bytes.", buf_in.len);
 
-	/* allocate buffer size */
-	if ((buf_in.ptr = malloc(buf_in.len)) == NULL) {
-		charra_log_error("Allocating %zu bytes of memory failed.", buf_in.len);
-		return CHARRA_RC_MARSHALING_ERROR;
-	}
-	charra_log_debug("Allocated %zu bytes of memory.", buf_in.len);
+    /* allocate buffer size */
+    if ((buf_in.ptr = malloc(buf_in.len)) == NULL) {
+        charra_log_error("Allocating %zu bytes of memory failed.", buf_in.len);
+        return CHARRA_RC_MARSHALING_ERROR;
+    }
+    charra_log_debug("Allocated %zu bytes of memory.", buf_in.len);
 
-	/* encode */
-	UsefulBufC buf_out = {.len = 0, .ptr = NULL};
-	if ((charra_r = charra_marshal_attestation_response_internal(
-			 attestation_response, buf_in, &buf_out)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("Could not marshal data.");
-		return charra_r;
-	}
+    /* encode */
+    UsefulBufC buf_out = {.len = 0, .ptr = NULL};
+    if ((charra_r = charra_marshal_attestation_response_internal(
+                 attestation_response, buf_in, &buf_out)) !=
+            CHARRA_RC_SUCCESS) {
+        charra_log_error("Could not marshal data.");
+        return charra_r;
+    }
 
-	/* set output parameters */
-	*marshaled_data_len = buf_out.len;
-	*marshaled_data = (uint8_t*)buf_out.ptr;
+    /* set output parameters */
+    *marshaled_data_len = buf_out.len;
+    *marshaled_data = (uint8_t*)buf_out.ptr;
 
-	return charra_r;
+    return charra_r;
 }
 
-// TODO implement this function using  QCBORDecode_* functions
+// TODO(any): Implement this function using  QCBORDecode_* functions.
 CHARRA_RC charra_unmarshal_attestation_response(
-	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
-	msg_attestation_response_dto* attestation_response) {
-	msg_attestation_response_dto res = {0};
+        const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
+        msg_attestation_response_dto* attestation_response) {
+    msg_attestation_response_dto res = {0};
 
-	QCBORError cborerr = QCBOR_SUCCESS;
-	UsefulBufC marshaled_data_buf = {marshaled_data, marshaled_data_len};
-	QCBORDecodeContext dc = {0};
-	QCBORItem item = {0};
+    QCBORError cborerr = QCBOR_SUCCESS;
+    UsefulBufC marshaled_data_buf = {marshaled_data, marshaled_data_len};
+    QCBORDecodeContext dc = {0};
+    QCBORItem item = {0};
 
-	QCBORDecode_Init(&dc, marshaled_data_buf, QCBOR_DECODE_MODE_NORMAL);
+    QCBORDecode_Init(&dc, marshaled_data_buf, QCBOR_DECODE_MODE_NORMAL);
 
-	/* parse root array */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
-		goto cbor_parse_error;
+    /* parse root array */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_ARRAY)))
+        goto cbor_parse_error;
 
-	/* parse "attestation-data" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	res.attestation_data_len = item.val.string.len;
-	memcpy(
-		&(res.attestation_data), item.val.string.ptr, res.attestation_data_len);
+    /* parse "attestation-data" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    res.attestation_data_len = item.val.string.len;
+    memcpy(&(res.attestation_data), item.val.string.ptr,
+            res.attestation_data_len);
 
-	/* parse "tpm2-signature" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	res.tpm2_signature_len = item.val.string.len;
-	memcpy(&(res.tpm2_signature), item.val.string.ptr, res.tpm2_signature_len);
+    /* parse "tpm2-signature" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    res.tpm2_signature_len = item.val.string.len;
+    memcpy(&(res.tpm2_signature), item.val.string.ptr, res.tpm2_signature_len);
 
-	/* parse "tpm2_public_key" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	res.tpm2_public_key_len = item.val.string.len;
-	memcpy(
-		&(res.tpm2_public_key), item.val.string.ptr, res.tpm2_public_key_len);
+    /* parse "tpm2_public_key" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    res.tpm2_public_key_len = item.val.string.len;
+    memcpy(&(res.tpm2_public_key), item.val.string.ptr,
+            res.tpm2_public_key_len);
 
-	/* parse "event-log" (bytes) */
-	if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
-		goto cbor_parse_error;
-	res.event_log_len = item.val.string.len;
-	uint8_t* event_log = (uint8_t*)malloc(res.event_log_len);
-	if (event_log == NULL) {
-		goto cbor_parse_error;
-	} else {
-		res.event_log = event_log;
-		if (memcpy(res.event_log, item.val.string.ptr, res.event_log_len) ==
-			NULL) {
-			goto cbor_parse_error;
-		}
-	}
+    /* parse "event-log" (bytes) */
+    if ((cborerr = charra_cbor_get_next(&dc, &item, QCBOR_TYPE_BYTE_STRING)))
+        goto cbor_parse_error;
+    res.event_log_len = item.val.string.len;
+    uint8_t* event_log = (uint8_t*)malloc(res.event_log_len);
+    if (event_log == NULL) {
+        goto cbor_parse_error;
+    } else {
+        res.event_log = event_log;
+        if (memcpy(res.event_log, item.val.string.ptr, res.event_log_len) ==
+                NULL) {
+            goto cbor_parse_error;
+        }
+    }
 
-	if ((cborerr = QCBORDecode_Finish(&dc))) {
-		charra_log_error("CBOR parser: expected end of input, but could not "
-						 "find it. Continuing.");
-		goto cbor_parse_error;
-	}
+    if ((cborerr = QCBORDecode_Finish(&dc))) {
+        charra_log_error("CBOR parser: expected end of input, but could not "
+                         "find it. Continuing.");
+        goto cbor_parse_error;
+    }
 
-	/* set output */
-	*attestation_response = res;
+    /* set output */
+    *attestation_response = res;
 
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 
 cbor_parse_error:
-	charra_log_error("CBOR parser: %s", qcbor_err_to_str(cborerr));
-	charra_log_info("CBOR parser: skipping parsing.");
+    charra_log_error("CBOR parser: %s", qcbor_err_to_str(cborerr));
+    charra_log_info("CBOR parser: skipping parsing.");
 
-	/* clean up */
-	charra_free_if_not_null(event_log);
+    /* clean up */
+    charra_free_if_not_null(event_log);
 
-	return CHARRA_RC_MARSHALING_ERROR;
+    return CHARRA_RC_MARSHALING_ERROR;
 }

--- a/src/core/charra_marshaling.h
+++ b/src/core/charra_marshaling.h
@@ -37,8 +37,8 @@
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC charra_marshal_attestation_request(
-	const msg_attestation_request_dto* attestation_request,
-	uint32_t* marshaled_data_len, uint8_t** marshaled_data);
+        const msg_attestation_request_dto* attestation_request,
+        uint32_t* marshaled_data_len, uint8_t** marshaled_data);
 
 /**
  * @brief Unmarshals an attestation request DTO.
@@ -50,8 +50,8 @@ CHARRA_RC charra_marshal_attestation_request(
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC charra_unmarshal_attestation_request(
-	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
-	msg_attestation_request_dto* attestation_request);
+        const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
+        msg_attestation_request_dto* attestation_request);
 
 /**
  * @brief Marshals an attestation response DTO.
@@ -63,8 +63,8 @@ CHARRA_RC charra_unmarshal_attestation_request(
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC charra_marshal_attestation_response(
-	const msg_attestation_response_dto* attestation_response,
-	uint32_t* marshaled_data_len, uint8_t** marshaled_data);
+        const msg_attestation_response_dto* attestation_response,
+        uint32_t* marshaled_data_len, uint8_t** marshaled_data);
 
 /**
  * @brief Unmarshals an attestation response DTO.
@@ -76,7 +76,7 @@ CHARRA_RC charra_marshal_attestation_response(
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC charra_unmarshal_attestation_response(
-	const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
-	msg_attestation_response_dto* attestation_response);
+        const uint32_t marshaled_data_len, const uint8_t* marshaled_data,
+        msg_attestation_response_dto* attestation_response);
 
 #endif /* MARSHALING_UTIL_H */

--- a/src/core/charra_rim_mgr.c
+++ b/src/core/charra_rim_mgr.c
@@ -34,11 +34,11 @@ uint32_t pcr_set_index = 0;
 uint32_t line_number = 1;
 
 static void free_reference_pcrs(
-	uint8_t** reference_pcrs, uint32_t reference_pcr_selection_len) {
-	for (uint32_t i = 0; i < reference_pcr_selection_len; i++) {
-		free(reference_pcrs[i]);
-	}
-	free(reference_pcrs);
+        uint8_t** reference_pcrs, uint32_t reference_pcr_selection_len) {
+    for (uint32_t i = 0; i < reference_pcr_selection_len; i++) {
+        free(reference_pcrs[i]);
+    }
+    free(reference_pcrs);
 }
 
 /**
@@ -57,33 +57,33 @@ static void free_reference_pcrs(
  * did not match, CHARRA_RC_ERROR on errors.
  */
 static CHARRA_RC handle_end_of_pcr_set(uint8_t** reference_pcrs,
-	const uint8_t* reference_pcr_selection,
-	const uint32_t reference_pcr_selection_len,
-	const TPMS_ATTEST* const attest_struct) {
-	if (pcr_selection_index < reference_pcr_selection_len) {
-		// we found an empty newline, but the previous set of PCRs was not
-		// complete.
-		charra_log_error(
-			"Error while parsing reference PCRs: "
-			"PCR set ending in line %d does not hold selected PCR %d.",
-			line_number, reference_pcr_selection[pcr_selection_index]);
-		return CHARRA_RC_ERROR;
-	}
+        const uint8_t* reference_pcr_selection,
+        const uint32_t reference_pcr_selection_len,
+        const TPMS_ATTEST* const attest_struct) {
+    if (pcr_selection_index < reference_pcr_selection_len) {
+        // we found an empty newline, but the previous set of PCRs was not
+        // complete.
+        charra_log_error(
+                "Error while parsing reference PCRs: "
+                "PCR set ending in line %d does not hold selected PCR %d.",
+                line_number, reference_pcr_selection[pcr_selection_index]);
+        return CHARRA_RC_ERROR;
+    }
 
-	charra_log_debug(
-		"Checking PCR composite digest at PCR set index %d:", pcr_set_index);
-	CHARRA_RC rc = compute_and_check_PCR_digest(
-		reference_pcrs, reference_pcr_selection_len, attest_struct);
-	if (rc == CHARRA_RC_ERROR) {
-		charra_log_error("Unexpected error while computing PCR digest at index "
-						 "%d of the PCR sets",
-			pcr_set_index);
-	} else if (rc == CHARRA_RC_SUCCESS) {
-		charra_log_info(
-			"Found matching PCR composite digest at index %d of the PCR sets.",
-			pcr_set_index);
-	}
-	return rc;
+    charra_log_debug("Checking PCR composite digest at PCR set index %d:",
+            pcr_set_index);
+    CHARRA_RC rc = compute_and_check_PCR_digest(
+            reference_pcrs, reference_pcr_selection_len, attest_struct);
+    if (rc == CHARRA_RC_ERROR) {
+        charra_log_error("Unexpected error while computing PCR digest at index "
+                         "%d of the PCR sets",
+                pcr_set_index);
+    } else if (rc == CHARRA_RC_SUCCESS) {
+        charra_log_info("Found matching PCR composite digest at index %d of "
+                        "the PCR sets.",
+                pcr_set_index);
+    }
+    return rc;
 }
 
 /**
@@ -99,144 +99,143 @@ static CHARRA_RC handle_end_of_pcr_set(uint8_t** reference_pcrs,
  * @returns CHARRA_RC_SUCCESS on success, CHARRA_RC_ERROR on errors.
  */
 static CHARRA_RC parse_pcr_value_line(char* index_char, char* eol,
-	uint8_t** reference_pcrs, const uint8_t* reference_pcr_selection,
-	const uint32_t reference_pcr_selection_len) {
-	if (pcr_selection_index < reference_pcr_selection_len) {
-		// only parse the line if we actually need another PCR for our digest,
-		// otherwise just skip it
-		int file_pcr_index = parse_pcr_index(index_char);
-		if (file_pcr_index < 0) {
-			charra_log_error(
-				"Error while parsing line %d from reference PCR file: "
-				"Unparseable PCR Index.",
-				line_number);
-			return CHARRA_RC_ERROR;
-		}
+        uint8_t** reference_pcrs, const uint8_t* reference_pcr_selection,
+        const uint32_t reference_pcr_selection_len) {
+    if (pcr_selection_index < reference_pcr_selection_len) {
+        // only parse the line if we actually need another PCR for our digest,
+        // otherwise just skip it
+        int file_pcr_index = parse_pcr_index(index_char);
+        if (file_pcr_index < 0) {
+            charra_log_error(
+                    "Error while parsing line %d from reference PCR file: "
+                    "Unparseable PCR Index.",
+                    line_number);
+            return CHARRA_RC_ERROR;
+        }
 
-		if (file_pcr_index == reference_pcr_selection[pcr_selection_index]) {
-			// PCR in current line is part of the PCR selection
-			CHARRA_RC charra_rc = parse_pcr_value(
-				index_char, eol, reference_pcrs[pcr_selection_index]);
-			if (charra_rc != CHARRA_RC_SUCCESS) {
-				charra_log_error("Error while parsing PCR value in "
-								 "line %d from reference PCR file.",
-					line_number);
-				return charra_rc;
-			}
-			// current selected PCR parsed, increase index
-			pcr_selection_index++;
-		}
-	}
-	return CHARRA_RC_SUCCESS;
+        if (file_pcr_index == reference_pcr_selection[pcr_selection_index]) {
+            // PCR in current line is part of the PCR selection
+            CHARRA_RC charra_rc = parse_pcr_value(
+                    index_char, eol, reference_pcrs[pcr_selection_index]);
+            if (charra_rc != CHARRA_RC_SUCCESS) {
+                charra_log_error("Error while parsing PCR value in "
+                                 "line %d from reference PCR file.",
+                        line_number);
+                return charra_rc;
+            }
+            // current selected PCR parsed, increase index
+            pcr_selection_index++;
+        }
+    }
+    return CHARRA_RC_SUCCESS;
 }
 
 CHARRA_RC charra_check_pcr_digest_against_reference(const char* filename,
-	const uint8_t* reference_pcr_selection,
-	const uint32_t reference_pcr_selection_len,
-	const TPMS_ATTEST* const attest_struct) {
+        const uint8_t* reference_pcr_selection,
+        const uint32_t reference_pcr_selection_len,
+        const TPMS_ATTEST* const attest_struct) {
+    /* sanity check */
+    if (reference_pcr_selection_len >= TPM2_MAX_PCRS) {
+        charra_log_error(
+                "Bad PCR selection length: %d.", reference_pcr_selection_len);
+        return CHARRA_RC_BAD_ARGUMENT;
+    }
 
-	/* sanity check */
-	if (reference_pcr_selection_len >= TPM2_MAX_PCRS) {
-		charra_log_error(
-			"Bad PCR selection length: %d.", reference_pcr_selection_len);
-		return CHARRA_RC_BAD_ARGUMENT;
-	}
+    // allocate memory for the pcr values read from the file
+    uint8_t** reference_pcrs =
+            malloc(reference_pcr_selection_len * sizeof(uint8_t*));
+    for (uint32_t i = 0; i < reference_pcr_selection_len; i++) {
+        reference_pcrs[i] = malloc(TPM2_SHA256_DIGEST_SIZE * sizeof(uint8_t));
+    }
+    char* file_content = NULL;
 
-	// allocate memory for the pcr values read from the file
-	uint8_t** reference_pcrs =
-		malloc(reference_pcr_selection_len * sizeof(uint8_t*));
-	for (uint32_t i = 0; i < reference_pcr_selection_len; i++) {
-		reference_pcrs[i] = malloc(TPM2_SHA256_DIGEST_SIZE * sizeof(uint8_t));
-	}
-	char* file_content = NULL;
+    CHARRA_RC charra_rc = CHARRA_RC_ERROR;
 
-	CHARRA_RC charra_rc = CHARRA_RC_ERROR;
+    if (filename != NULL) {
+        /* read reference PCR file */
+        size_t file_size = 0;
+        CHARRA_RC read_result =
+                charra_io_read_file(filename, &file_content, &file_size);
+        if (read_result != CHARRA_RC_SUCCESS) {
+            return read_result;
+        }
 
-	if (filename != NULL) {
-		/* read reference PCR file */
-		size_t file_size = 0;
-		CHARRA_RC read_result =
-			charra_io_read_file(filename, &file_content, &file_size);
-		if (read_result != CHARRA_RC_SUCCESS) {
-			return read_result;
-		}
+        pcr_selection_index = 0;
+        pcr_set_index = 0;
+        line_number = 1;
+        for (char* c = file_content; c < file_content + file_size; c++) {
+            /* c is somewhere at the beginning of a new line. loop over file
+             * contents until we find a digit (assumed to be a PCR index) or
+             * '\n' signaling a new line. If we find the PCR index, we parse the
+             * rest of the line and set c to end of the line, thus the next
+             * iteration will be at the start of the next line. If we find '\n'
+             * before we find a PCR index, this means we found an empty newline,
+             * which signals a new set of reference PCR values. Thus we need to
+             * compare the digest of the current set of PCRs to the digest of
+             * the attester and then clear the current set of reference PCRs
+             * from memory.
+             */
 
-		pcr_selection_index = 0;
-		pcr_set_index = 0;
-		line_number = 1;
-		for (char* c = file_content; c < file_content + file_size; c++) {
-			/* c is somewhere at the beginning of a new line. loop over file
-			 * contents until we find a digit (assumed to be a PCR index) or
-			 * '\n' signaling a new line. If we find the PCR index, we parse the
-			 * rest of the line and set c to end of the line, thus the next
-			 * iteration will be at the start of the next line. If we find '\n'
-			 * before we find a PCR index, this means we found an empty newline,
-			 * which signals a new set of reference PCR values. Thus we need to
-			 * compare the digest of the current set of PCRs to the digest of
-			 * the attester and then clear the current set of reference PCRs
-			 * from memory.
-			 */
+            if (*c == '\n') {
+                // we are on an empty newline because we found two '\n' without
+                // a PCR index inbetween
+                charra_rc = handle_end_of_pcr_set(reference_pcrs,
+                        reference_pcr_selection, reference_pcr_selection_len,
+                        attest_struct);
+                // do not return when digests don't match, we have more PCR sets
+                // to try out
+                if (charra_rc != CHARRA_RC_NO_MATCH) {
+                    goto returns;
+                }
 
-			if (*c == '\n') {
-				// we are on an empty newline because we found two '\n' without
-				// a PCR index inbetween
-				charra_rc = handle_end_of_pcr_set(reference_pcrs,
-					reference_pcr_selection, reference_pcr_selection_len,
-					attest_struct);
-				// do not return when digests don't match, we have more PCR sets
-				// to try out
-				if (charra_rc != CHARRA_RC_NO_MATCH) {
-					goto returns;
-				}
+                pcr_selection_index = 0;
+                pcr_set_index++;
+                line_number++;
+            }
 
-				pcr_selection_index = 0;
-				pcr_set_index++;
-				line_number++;
-			}
+            if (isdigit(*c) > 0) {
+                // *c is a digit, we are at the start of an index
+                char* eol = find_end_of_line(c, file_content + file_size);
 
-			if (isdigit(*c) > 0) {
-				//*c is a digit, we are at the start of an index
-				char* eol = find_end_of_line(c, file_content + file_size);
-
-				charra_rc = parse_pcr_value_line(c, eol, reference_pcrs,
-					reference_pcr_selection, reference_pcr_selection_len);
-				if (charra_rc != CHARRA_RC_SUCCESS) {
-					goto returns;
-				}
-				// set c (current char) to eol because the whole line has been
-				// parsed
-				c = eol;
-				line_number++;
-			}
-		}
-		if (pcr_selection_index != 0) {
-			// The last PCR set was not yet handled
-			charra_rc =
-				handle_end_of_pcr_set(reference_pcrs, reference_pcr_selection,
-					reference_pcr_selection_len, attest_struct);
-			goto returns;
-		}
-		// end of reference PCR file and no matching PCR composite digest found
-		charra_rc = CHARRA_RC_VERIFICATION_FAILED;
-	} else {
-		// filename was NULL, assume that empty PCRs shall be used as reference
-		// PCRs
-		charra_log_warn("Using empty PCRs as reference PCRs");
-		for (size_t i = 0; i < reference_pcr_selection_len; ++i) {
-			for (uint32_t j = 0; j < TPM2_SHA256_DIGEST_SIZE; ++j) {
-				reference_pcrs[i][j] = 0;
-			}
-		}
-		charra_rc = compute_and_check_PCR_digest(
-			reference_pcrs, reference_pcr_selection_len, attest_struct);
-	}
+                charra_rc = parse_pcr_value_line(c, eol, reference_pcrs,
+                        reference_pcr_selection, reference_pcr_selection_len);
+                if (charra_rc != CHARRA_RC_SUCCESS) {
+                    goto returns;
+                }
+                // set c (current char) to eol because the whole line has been
+                // parsed
+                c = eol;
+                line_number++;
+            }
+        }
+        if (pcr_selection_index != 0) {
+            // The last PCR set was not yet handled
+            charra_rc = handle_end_of_pcr_set(reference_pcrs,
+                    reference_pcr_selection, reference_pcr_selection_len,
+                    attest_struct);
+            goto returns;
+        }
+        // end of reference PCR file and no matching PCR composite digest found
+        charra_rc = CHARRA_RC_VERIFICATION_FAILED;
+    } else {
+        // filename was NULL, assume that empty PCRs shall be used as reference
+        // PCRs
+        charra_log_warn("Using empty PCRs as reference PCRs");
+        for (size_t i = 0; i < reference_pcr_selection_len; ++i) {
+            for (uint32_t j = 0; j < TPM2_SHA256_DIGEST_SIZE; ++j) {
+                reference_pcrs[i][j] = 0;
+            }
+        }
+        charra_rc = compute_and_check_PCR_digest(
+                reference_pcrs, reference_pcr_selection_len, attest_struct);
+    }
 
 returns:
-	if (charra_rc == CHARRA_RC_NO_MATCH) {
-		// no match until end of reference PCR file, verification failed.
-		charra_rc = CHARRA_RC_VERIFICATION_FAILED;
-	}
-	charra_free_if_not_null(file_content);
-	free_reference_pcrs(reference_pcrs, reference_pcr_selection_len);
-	return charra_rc;
+    if (charra_rc == CHARRA_RC_NO_MATCH) {
+        // no match until end of reference PCR file, verification failed.
+        charra_rc = CHARRA_RC_VERIFICATION_FAILED;
+    }
+    charra_free_if_not_null(file_content);
+    free_reference_pcrs(reference_pcrs, reference_pcr_selection_len);
+    return charra_rc;
 }

--- a/src/core/charra_rim_mgr.h
+++ b/src/core/charra_rim_mgr.h
@@ -52,8 +52,8 @@
  * CHARRA_RC_ERROR on errors.
  */
 CHARRA_RC charra_check_pcr_digest_against_reference(const char* filename,
-	const uint8_t* reference_pcr_selection,
-	const uint32_t reference_pcr_selection_len,
-	const TPMS_ATTEST* const attest_struct);
+        const uint8_t* reference_pcr_selection,
+        const uint32_t reference_pcr_selection_len,
+        const TPMS_ATTEST* const attest_struct);
 
 #endif /* CHARRA_RIM_MGR_H */

--- a/src/util/cbor_util.c
+++ b/src/util/cbor_util.c
@@ -30,98 +30,98 @@
 #include "../common/charra_log.h"
 
 const char* cbor_type_string(const uint8_t type) {
-	switch (type) {
-	case QCBOR_TYPE_NONE:
-		return "CborInvalidType";
-	case QCBOR_TYPE_INT64:
-		return "CborIntegerType";
-	case QCBOR_TYPE_UINT64:
-		return "CborUnsignedIntegerType";
-	case QCBOR_TYPE_ARRAY:
-		return "CborArrayType";
-	case QCBOR_TYPE_MAP:
-		return "CborMapType";
-	case QCBOR_TYPE_BYTE_STRING:
-		return "CborByteStringType";
-	case QCBOR_TYPE_TEXT_STRING:
-		return "CborTextStringType";
-	case QCBOR_TYPE_POSBIGNUM:
-		return "CborPositiveBigIntegerType";
-	case QCBOR_TYPE_NEGBIGNUM:
-		return "CborNegativeBigIntegerType";
-	case QCBOR_TYPE_DATE_STRING:
-		return "CborDateStringType";
-	case QCBOR_TYPE_DATE_EPOCH:
-		return "CborDateEpochType";
-	case QCBOR_TYPE_UKNOWN_SIMPLE:
-		return "CborUnknownSimpleType";
-	case QCBOR_TYPE_DECIMAL_FRACTION:
-		return "CborDecimalFractionType";
-	case QCBOR_TYPE_DECIMAL_FRACTION_POS_BIGNUM:
-		return "CborPostivieDecimalFractionType";
-	case QCBOR_TYPE_DECIMAL_FRACTION_NEG_BIGNUM:
-		return "CborNegativeDecimalFractionType";
-	case QCBOR_TYPE_BIGFLOAT:
-		return "CborBigfloatType";
-	case QCBOR_TYPE_BIGFLOAT_POS_BIGNUM:
-		return "CborPositiveBigfloatType";
-	case QCBOR_TYPE_BIGFLOAT_NEG_BIGNUM:
-		return "CborNegativeBigfloatType";
-	case QCBOR_TYPE_FALSE:
-		return "CborFalseType";
-	case QCBOR_TYPE_TRUE:
-		return "CborFalseType";
-	case QCBOR_TYPE_NULL:
-		return "CborNullType";
-	case QCBOR_TYPE_UNDEF:
-		return "CborUndefType";
-	case QCBOR_TYPE_FLOAT:
-		return "CborFloatType";
-	case QCBOR_TYPE_DOUBLE:
-		return "CborDoubleType";
-	case QCBOR_TYPE_MAP_AS_ARRAY:
-		return "CborMapAsArrayType";
-	case CHARRA_CBOR_TYPE_BOOLEAN:
-		return "CharraCborBooleanType";
-	default:
-		return "UNKNOWN";
-	}
+    switch (type) {
+    case QCBOR_TYPE_NONE:
+        return "CborInvalidType";
+    case QCBOR_TYPE_INT64:
+        return "CborIntegerType";
+    case QCBOR_TYPE_UINT64:
+        return "CborUnsignedIntegerType";
+    case QCBOR_TYPE_ARRAY:
+        return "CborArrayType";
+    case QCBOR_TYPE_MAP:
+        return "CborMapType";
+    case QCBOR_TYPE_BYTE_STRING:
+        return "CborByteStringType";
+    case QCBOR_TYPE_TEXT_STRING:
+        return "CborTextStringType";
+    case QCBOR_TYPE_POSBIGNUM:
+        return "CborPositiveBigIntegerType";
+    case QCBOR_TYPE_NEGBIGNUM:
+        return "CborNegativeBigIntegerType";
+    case QCBOR_TYPE_DATE_STRING:
+        return "CborDateStringType";
+    case QCBOR_TYPE_DATE_EPOCH:
+        return "CborDateEpochType";
+    case QCBOR_TYPE_UKNOWN_SIMPLE:
+        return "CborUnknownSimpleType";
+    case QCBOR_TYPE_DECIMAL_FRACTION:
+        return "CborDecimalFractionType";
+    case QCBOR_TYPE_DECIMAL_FRACTION_POS_BIGNUM:
+        return "CborPostivieDecimalFractionType";
+    case QCBOR_TYPE_DECIMAL_FRACTION_NEG_BIGNUM:
+        return "CborNegativeDecimalFractionType";
+    case QCBOR_TYPE_BIGFLOAT:
+        return "CborBigfloatType";
+    case QCBOR_TYPE_BIGFLOAT_POS_BIGNUM:
+        return "CborPositiveBigfloatType";
+    case QCBOR_TYPE_BIGFLOAT_NEG_BIGNUM:
+        return "CborNegativeBigfloatType";
+    case QCBOR_TYPE_FALSE:
+        return "CborFalseType";
+    case QCBOR_TYPE_TRUE:
+        return "CborFalseType";
+    case QCBOR_TYPE_NULL:
+        return "CborNullType";
+    case QCBOR_TYPE_UNDEF:
+        return "CborUndefType";
+    case QCBOR_TYPE_FLOAT:
+        return "CborFloatType";
+    case QCBOR_TYPE_DOUBLE:
+        return "CborDoubleType";
+    case QCBOR_TYPE_MAP_AS_ARRAY:
+        return "CborMapAsArrayType";
+    case CHARRA_CBOR_TYPE_BOOLEAN:
+        return "CharraCborBooleanType";
+    default:
+        return "UNKNOWN";
+    }
 }
 
-CHARRA_RC charra_cbor_get_next(
-	QCBORDecodeContext* ctx, QCBORItem* decoded_item, uint8_t expected_type) {
-	uint8_t type = 0;
-	bool is_expected_type = false;
+CHARRA_RC charra_cbor_get_next(QCBORDecodeContext* ctx, QCBORItem* decoded_item,
+        uint8_t expected_type) {
+    uint8_t type = 0;
+    bool is_expected_type = false;
 
-	if (QCBORDecode_GetNext(ctx, decoded_item)) {
-		charra_log_error("CBOR Parser: Error getting next item");
-		return CHARRA_RC_MARSHALING_ERROR;
-	}
+    if (QCBORDecode_GetNext(ctx, decoded_item)) {
+        charra_log_error("CBOR Parser: Error getting next item");
+        return CHARRA_RC_MARSHALING_ERROR;
+    }
 
-	if (expected_type != QCBOR_TYPE_NONE) {
-		/* expect particular CBOR type */
-		type = decoded_item->uDataType;
-		is_expected_type = type == expected_type;
-		if (expected_type == CHARRA_CBOR_TYPE_BOOLEAN) {
-			is_expected_type =
-				type == QCBOR_TYPE_FALSE || type == QCBOR_TYPE_TRUE;
-		}
-		if (!is_expected_type) {
-			charra_log_error("CBOR parser: expected type %s, found type %s.",
-				cbor_type_string(expected_type), cbor_type_string(type));
-			return CHARRA_RC_MARSHALING_ERROR;
-		}
-		charra_log_debug("CBOR parser: found type %s.", cbor_type_string(type));
-	}
+    if (expected_type != QCBOR_TYPE_NONE) {
+        /* expect particular CBOR type */
+        type = decoded_item->uDataType;
+        is_expected_type = type == expected_type;
+        if (expected_type == CHARRA_CBOR_TYPE_BOOLEAN) {
+            is_expected_type =
+                    type == QCBOR_TYPE_FALSE || type == QCBOR_TYPE_TRUE;
+        }
+        if (!is_expected_type) {
+            charra_log_error("CBOR parser: expected type %s, found type %s.",
+                    cbor_type_string(expected_type), cbor_type_string(type));
+            return CHARRA_RC_MARSHALING_ERROR;
+        }
+        charra_log_debug("CBOR parser: found type %s.", cbor_type_string(type));
+    }
 
-	/* return positive result */
-	return CHARRA_RC_SUCCESS;
+    /* return positive result */
+    return CHARRA_RC_SUCCESS;
 }
 
 bool charra_cbor_get_bool_val(QCBORItem* item) {
-	if (item->uDataType == QCBOR_TYPE_TRUE) {
-		return true;
-	}
+    if (item->uDataType == QCBOR_TYPE_TRUE) {
+        return true;
+    }
 
-	return false;
+    return false;
 }

--- a/src/util/cbor_util.h
+++ b/src/util/cbor_util.h
@@ -45,8 +45,8 @@ const char* cbor_type_string(const uint8_t type);
  * @return CHARRA_RC_SUCCESS in case of success
  * @return CHARRA_RC_MARSHALING_ERROR in case an error occurred
  */
-CHARRA_RC charra_cbor_get_next(
-	QCBORDecodeContext* ctx, QCBORItem* decoded_item, uint8_t expected_type);
+CHARRA_RC charra_cbor_get_next(QCBORDecodeContext* ctx, QCBORItem* decoded_item,
+        uint8_t expected_type);
 
 /**
  * @brief Reads a boolean value from a CBOR item.

--- a/src/util/charra_util.c
+++ b/src/util/charra_util.c
@@ -45,203 +45,202 @@
 #define CHARRA_UNUSED __attribute__((unused))
 
 static const unsigned char mbedtls_personalization[] =
-	"CHARRA_mbedtls_random_personalization";
+        "CHARRA_mbedtls_random_personalization";
 static const unsigned char mbedtls_personalization_len =
-	sizeof(mbedtls_personalization);
+        sizeof(mbedtls_personalization);
 
 CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* random_bytes) {
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
-	/* initialize contexts */
-	mbedtls_entropy_context entropy = {0};
-	mbedtls_entropy_init(&entropy);
-	mbedtls_ctr_drbg_context ctr_drbg = {0};
-	mbedtls_ctr_drbg_init(&ctr_drbg);
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    /* initialize contexts */
+    mbedtls_entropy_context entropy = {0};
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_context ctr_drbg = {0};
+    mbedtls_ctr_drbg_init(&ctr_drbg);
 
-	/* add seed */
-	if (mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
-			mbedtls_personalization, mbedtls_personalization_len) != 0) {
-		charra_r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* add seed */
+    if (mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                mbedtls_personalization, mbedtls_personalization_len) != 0) {
+        charra_r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	/* add prediction resistance */
-	mbedtls_ctr_drbg_set_prediction_resistance(
-		&ctr_drbg, MBEDTLS_CTR_DRBG_PR_ON);
+    /* add prediction resistance */
+    mbedtls_ctr_drbg_set_prediction_resistance(
+            &ctr_drbg, MBEDTLS_CTR_DRBG_PR_ON);
 
-	if (mbedtls_ctr_drbg_random(
-			&ctr_drbg, (unsigned char*)random_bytes, (size_t)len) != 0) {
-		charra_r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if (mbedtls_ctr_drbg_random(
+                &ctr_drbg, (unsigned char*)random_bytes, (size_t)len) != 0) {
+        charra_r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	/* clean up */
-	mbedtls_ctr_drbg_free(&ctr_drbg);
-	mbedtls_entropy_free(&entropy);
+    /* clean up */
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);
 
-	return charra_r;
+    return charra_r;
 }
 
 CHARRA_RC charra_random_bytes_from_tpm(
-	const uint32_t len, uint8_t* random_bytes) {
-	assert(len <= sizeof(TPMU_HA));
+        const uint32_t len, uint8_t* random_bytes) {
+    assert(len <= sizeof(TPMU_HA));
 
-	TSS2_RC tss2_rc = 0;
-	char* error_msg = NULL;
-	ESYS_CONTEXT* ctx = NULL;
+    TSS2_RC tss2_rc = 0;
+    char* error_msg = NULL;
+    ESYS_CONTEXT* ctx = NULL;
 
-	TPM2B_DIGEST* tpm_random_bytes = NULL;
+    TPM2B_DIGEST* tpm_random_bytes = NULL;
 
-	TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
-	if ((tss2_rc = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
-		TSS2_RC_SUCCESS) {
-		error_msg = "TPM2 Tss2_TctiLdr_Initialize failed.";
-		goto error;
-	}
-	if ((tss2_rc = Esys_Initialize(&ctx, tcti_ctx, NULL)) != TSS2_RC_SUCCESS) {
-		error_msg = "TPM2 Esys_Initialize failed.";
-		goto error;
-	}
+    TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
+    if ((tss2_rc = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
+            TSS2_RC_SUCCESS) {
+        error_msg = "TPM2 Tss2_TctiLdr_Initialize failed.";
+        goto error;
+    }
+    if ((tss2_rc = Esys_Initialize(&ctx, tcti_ctx, NULL)) != TSS2_RC_SUCCESS) {
+        error_msg = "TPM2 Esys_Initialize failed.";
+        goto error;
+    }
 
-	if ((tss2_rc = tpm2_get_random(ctx, len, &tpm_random_bytes)) !=
-		TSS2_RC_SUCCESS) {
-		error_msg = "TPM2 get random failed";
-		goto error;
-	}
+    if ((tss2_rc = tpm2_get_random(ctx, len, &tpm_random_bytes)) !=
+            TSS2_RC_SUCCESS) {
+        error_msg = "TPM2 get random failed";
+        goto error;
+    }
 
-	/* set out params */
-	memcpy(random_bytes, tpm_random_bytes->buffer, len);
+    /* set out params */
+    memcpy(random_bytes, tpm_random_bytes->buffer, len);
 
 error:
-	/* print error message */
-	if (error_msg != NULL) {
-		charra_log_error("%s (TSS2_RC: 0x%04x)", error_msg, tss2_rc);
-	}
+    /* print error message */
+    if (error_msg != NULL) {
+        charra_log_error("%s (TSS2_RC: 0x%04x)", error_msg, tss2_rc);
+    }
 
-	/* free ESAPI objects */
-	if (tpm_random_bytes != NULL) {
-		Esys_Free(tpm_random_bytes);
-	}
+    /* free ESAPI objects */
+    if (tpm_random_bytes != NULL) {
+        Esys_Free(tpm_random_bytes);
+    }
 
-	/* finalize ESAPI */
-	Esys_Finalize(&ctx);
-	Tss2_TctiLdr_Finalize(&tcti_ctx);
+    /* finalize ESAPI */
+    Esys_Finalize(&ctx);
+    Tss2_TctiLdr_Finalize(&tcti_ctx);
 
-	/* transform TSS2_RC to CHARRA_RC */
-	CHARRA_RC charra_rc =
-		(tss2_rc == TSS2_RC_SUCCESS) ? CHARRA_RC_SUCCESS : CHARRA_RC_TPM;
+    /* transform TSS2_RC to CHARRA_RC */
+    CHARRA_RC charra_rc =
+            (tss2_rc == TSS2_RC_SUCCESS) ? CHARRA_RC_SUCCESS : CHARRA_RC_TPM;
 
-	return charra_rc;
+    return charra_rc;
 }
 
 TSS2_RC charra_verify_tpm2_quote_signature_with_tpm(ESYS_CONTEXT* ctx,
-	const ESYS_TR sig_key_handle, const TPM2_ALG_ID hash_algo_id,
-	const TPM2B_ATTEST* attest_buf, TPMT_SIGNATURE* signature,
-	TPMT_TK_VERIFIED** validation) {
-	TSS2_RC tss2_r = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+        const ESYS_TR sig_key_handle, const TPM2_ALG_ID hash_algo_id,
+        const TPM2B_ATTEST* attest_buf, TPMT_SIGNATURE* signature,
+        TPMT_TK_VERIFIED** validation) {
+    TSS2_RC tss2_r = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* prepare buffer */
-	TPM2B_MAX_BUFFER data = {.size = attest_buf->size};
-	memcpy(data.buffer, (const uint8_t*)&attest_buf->attestationData,
-		attest_buf->size);
+    /* prepare buffer */
+    TPM2B_MAX_BUFFER data = {.size = attest_buf->size};
+    memcpy(data.buffer, (const uint8_t*)&attest_buf->attestationData,
+            attest_buf->size);
 
-	/* hash relevant attestation data for verification */
-	TPM2B_DIGEST* attestation_data_digest = NULL;
-	TPMT_TK_HASHCHECK* hash_validation = NULL;
-	if ((tss2_r = Esys_Hash(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
-			 &data, hash_algo_id, TPM2_RH_OWNER, &attestation_data_digest,
-			 &hash_validation)) != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_Hash";
-		goto error;
-	}
+    /* hash relevant attestation data for verification */
+    TPM2B_DIGEST* attestation_data_digest = NULL;
+    TPMT_TK_HASHCHECK* hash_validation = NULL;
+    if ((tss2_r = Esys_Hash(ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE,
+                 &data, hash_algo_id, TPM2_RH_OWNER, &attestation_data_digest,
+                 &hash_validation)) != TSS2_RC_SUCCESS) {
+        error_msg = "Esys_Hash";
+        goto error;
+    }
 
-	/* verify quote signature */
-	if ((tss2_r = Esys_VerifySignature(ctx, sig_key_handle, ESYS_TR_NONE,
-			 ESYS_TR_NONE, ESYS_TR_NONE, attestation_data_digest, signature,
-			 validation)) != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_VerifySignature";
-		goto error;
-	}
+    /* verify quote signature */
+    if ((tss2_r = Esys_VerifySignature(ctx, sig_key_handle, ESYS_TR_NONE,
+                 ESYS_TR_NONE, ESYS_TR_NONE, attestation_data_digest, signature,
+                 validation)) != TSS2_RC_SUCCESS) {
+        error_msg = "Esys_VerifySignature";
+        goto error;
+    }
 
 error:
-	/* print error message */
-	if (error_msg != NULL) {
-		charra_log_error("%s (TSS2_RC: 0x%04x)", error_msg, tss2_r);
-	}
+    /* print error message */
+    if (error_msg != NULL) {
+        charra_log_error("%s (TSS2_RC: 0x%04x)", error_msg, tss2_r);
+    }
 
-	/* free ESAPI objects */
-	if (hash_validation != NULL) {
-		Esys_Free(hash_validation);
-	}
-	if (attestation_data_digest != NULL) {
-		Esys_Free(attestation_data_digest);
-	}
+    /* free ESAPI objects */
+    if (hash_validation != NULL) {
+        Esys_Free(hash_validation);
+    }
+    if (attestation_data_digest != NULL) {
+        Esys_Free(attestation_data_digest);
+    }
 
-	return tss2_r;
+    return tss2_r;
 }
 
 CHARRA_RC charra_unmarshal_tpm2_quote(size_t attest_buf_len,
-	const uint8_t* attest_buf, TPMS_ATTEST* attest_struct) {
-	CHARRA_RC charra_rc = CHARRA_RC_SUCCESS;
-	TSS2_RC tss2_rc = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+        const uint8_t* attest_buf, TPMS_ATTEST* attest_struct) {
+    CHARRA_RC charra_rc = CHARRA_RC_SUCCESS;
+    TSS2_RC tss2_rc = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* verify input parameters */
-	if (attest_buf == NULL) {
-		error_msg = "Bad argument. attest_buf is NULL.";
-		charra_rc = CHARRA_RC_BAD_ARGUMENT;
-		goto error;
-	} else if (attest_struct == NULL) {
-		error_msg = "Bad argument. attest_struct is NULL.";
-		charra_rc = CHARRA_RC_BAD_ARGUMENT;
-		goto error;
-	}
+    /* verify input parameters */
+    if (attest_buf == NULL) {
+        error_msg = "Bad argument. attest_buf is NULL.";
+        charra_rc = CHARRA_RC_BAD_ARGUMENT;
+        goto error;
+    } else if (attest_struct == NULL) {
+        error_msg = "Bad argument. attest_struct is NULL.";
+        charra_rc = CHARRA_RC_BAD_ARGUMENT;
+        goto error;
+    }
 
-	/* unmarshal TPMS_ATTEST structure */
-	size_t offset = 0;
-	if ((tss2_rc = Tss2_MU_TPMS_ATTEST_Unmarshal(attest_buf, attest_buf_len,
-			 &offset, attest_struct)) != TSS2_RC_SUCCESS) {
-		error_msg = "Unmarshal TPMS_ATTEST structure.";
-		charra_rc = CHARRA_RC_MARSHALING_ERROR;
-		goto error;
-	}
+    /* unmarshal TPMS_ATTEST structure */
+    size_t offset = 0;
+    if ((tss2_rc = Tss2_MU_TPMS_ATTEST_Unmarshal(attest_buf, attest_buf_len,
+                 &offset, attest_struct)) != TSS2_RC_SUCCESS) {
+        error_msg = "Unmarshal TPMS_ATTEST structure.";
+        charra_rc = CHARRA_RC_MARSHALING_ERROR;
+        goto error;
+    }
 
 error:
-	/* print error message */
-	if (error_msg != NULL) {
-		charra_log_error("%s (CHARRA RC: 0x%04x, TSS2 RC: 0x%04x)", error_msg,
-			charra_rc, tss2_rc);
-	}
+    /* print error message */
+    if (error_msg != NULL) {
+        charra_log_error("%s (CHARRA RC: 0x%04x, TSS2 RC: 0x%04x)", error_msg,
+                charra_rc, tss2_rc);
+    }
 
-	/* transform TSS2_RC to CHARRA_RC */
-	if ((charra_rc == CHARRA_RC_SUCCESS) && (tss2_rc != TSS2_RC_SUCCESS)) {
-		charra_rc = CHARRA_RC_TPM;
-	}
+    /* transform TSS2_RC to CHARRA_RC */
+    if ((charra_rc == CHARRA_RC_SUCCESS) && (tss2_rc != TSS2_RC_SUCCESS)) {
+        charra_rc = CHARRA_RC_TPM;
+    }
 
-	return charra_rc;
+    return charra_rc;
 }
 
 bool charra_verify_tpm2_quote_qualifying_data(uint16_t qualifying_data_len,
-	const uint8_t* const qualifying_data,
-	const TPMS_ATTEST* const attest_struct) {
+        const uint8_t* const qualifying_data,
+        const TPMS_ATTEST* const attest_struct) {
+    /* verify input parameters */
+    if (qualifying_data == NULL) {
+        return false;
+    } else if (attest_struct == NULL) {
+        return false;
+    }
 
-	/* verify input parameters */
-	if (qualifying_data == NULL) {
-		return false;
-	} else if (attest_struct == NULL) {
-		return false;
-	}
+    /* compare sizes and content */
+    if (attest_struct->extraData.size != qualifying_data_len) {
+        return false;
+    } else if (memcmp(qualifying_data, attest_struct->extraData.buffer,
+                       qualifying_data_len) != 0) {
+        return false;
+    }
 
-	/* compare sizes and content */
-	if (attest_struct->extraData.size != qualifying_data_len) {
-		return false;
-	} else if (memcmp(qualifying_data, attest_struct->extraData.buffer,
-				   qualifying_data_len) != 0) {
-		return false;
-	}
-
-	return true;
+    return true;
 }
 
 /* TODO Add specific versions of this function for all supported hash algos,
@@ -249,30 +248,29 @@ bool charra_verify_tpm2_quote_qualifying_data(uint16_t qualifying_data_len,
  * invoking this generic funtion internally with TPM2_SHA256_DIGEST_SIZE, etc.
  */
 CHARRA_RC charra_compute_pcr_composite_digest_from_ptr_array(
-	uint16_t hash_algo_digest_size CHARRA_UNUSED,
-	const uint8_t* expected_pcr_values[] CHARRA_UNUSED,
-	size_t expected_pcr_values_len CHARRA_UNUSED,
-	uint8_t* pcr_composite_digest CHARRA_UNUSED) {
-	// TODO: to be implemented
-	return CHARRA_RC_NOT_YET_IMPLEMENTED;
+        uint16_t hash_algo_digest_size CHARRA_UNUSED,
+        const uint8_t* expected_pcr_values[] CHARRA_UNUSED,
+        size_t expected_pcr_values_len CHARRA_UNUSED,
+        uint8_t* pcr_composite_digest CHARRA_UNUSED) {
+    // TODO(any): to be implemented
+    return CHARRA_RC_NOT_YET_IMPLEMENTED;
 }
 
 bool charra_verify_tpm2_quote_pcr_composite_digest(
-	const TPMS_ATTEST* const attest_struct,
-	const uint8_t* const pcr_composite_digest,
-	const uint16_t pcr_composite_digest_len) {
+        const TPMS_ATTEST* const attest_struct,
+        const uint8_t* const pcr_composite_digest,
+        const uint16_t pcr_composite_digest_len) {
+    /* extract PCR digest from attestation structure */
+    TPMS_QUOTE_INFO quote_info = attest_struct->attested.quote;
+    const uint8_t* const pcr_digest = quote_info.pcrDigest.buffer;
+    uint16_t pcr_digest_size = quote_info.pcrDigest.size;
 
-	/* extract PCR digest from attestation structure */
-	TPMS_QUOTE_INFO quote_info = attest_struct->attested.quote;
-	const uint8_t* const pcr_digest = quote_info.pcrDigest.buffer;
-	uint16_t pcr_digest_size = quote_info.pcrDigest.size;
+    /* compare digests */
+    if (pcr_digest_size != pcr_composite_digest_len) {
+        return false;
+    } else if (memcmp(pcr_digest, pcr_composite_digest, pcr_digest_size) != 0) {
+        return false;
+    }
 
-	/* compare digests */
-	if (pcr_digest_size != pcr_composite_digest_len) {
-		return false;
-	} else if (memcmp(pcr_digest, pcr_composite_digest, pcr_digest_size) != 0) {
-		return false;
-	}
-
-	return true;
+    return true;
 }

--- a/src/util/charra_util.h
+++ b/src/util/charra_util.h
@@ -48,7 +48,7 @@ CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* random_bytes);
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC charra_random_bytes_from_tpm(
-	const uint32_t len, uint8_t* random_bytes);
+        const uint32_t len, uint8_t* random_bytes);
 
 /**
  * @brief Verifies a TPM 2.0 quote using the TPM.
@@ -62,23 +62,23 @@ CHARRA_RC charra_random_bytes_from_tpm(
  * @return TSS2_RC The TSS return code.
  */
 CHARRA_RC charra_verify_tpm2_quote_signature_with_tpm(ESYS_CONTEXT* ctx,
-	const ESYS_TR sig_key_handle, const TPM2_ALG_ID hash_algo_id,
-	const TPM2B_ATTEST* attest_buf, TPMT_SIGNATURE* signature,
-	TPMT_TK_VERIFIED** validation);
+        const ESYS_TR sig_key_handle, const TPM2_ALG_ID hash_algo_id,
+        const TPM2B_ATTEST* attest_buf, TPMT_SIGNATURE* signature,
+        TPMT_TK_VERIFIED** validation);
 
 CHARRA_RC charra_unmarshal_tpm2_quote(size_t attest_buf_len,
-	const uint8_t* attest_buf, TPMS_ATTEST* attest_struct);
+        const uint8_t* attest_buf, TPMS_ATTEST* attest_struct);
 
 bool charra_verify_tpm2_quote_qualifying_data(uint16_t qualifying_data_len,
-	const uint8_t* const qualifying_data,
-	const TPMS_ATTEST* const attest_struct);
+        const uint8_t* const qualifying_data,
+        const TPMS_ATTEST* const attest_struct);
 
 bool charra_verify_tpm2_quote_pcrs(TPM2_ALG_ID hash_algo_id,
-	const uint8_t* const qualifying_data,
-	const TPMS_ATTEST* const attest_struct);
+        const uint8_t* const qualifying_data,
+        const TPMS_ATTEST* const attest_struct);
 
 bool charra_verify_tpm2_quote_pcr_composite_digest(
-	const TPMS_ATTEST* const attest_struct, const uint8_t* const pcr_composite,
-	const uint16_t pcr_composite_len);
+        const TPMS_ATTEST* const attest_struct,
+        const uint8_t* const pcr_composite, const uint16_t pcr_composite_len);
 
 #endif /* CHARRA_UTIL_H */

--- a/src/util/cli_util.c
+++ b/src/util/cli_util.c
@@ -29,431 +29,388 @@
 
 /* command line argument handling */
 static const struct option verifier_options[] = {
-	{"verbose", no_argument, 0, 'v'}, {"log-level", required_argument, 0, 'l'},
-	{"coap-log-level", required_argument, 0, 'c'},
-	{"timeout", required_argument, 0, 't'},
-	{"pcr-file", required_argument, 0, 'f'},
-	{"pcr-selection", required_argument, 0, 's'}, {"psk", no_argument, 0, 'p'},
-	{"key", required_argument, 0, 'k'}, {"identity", required_argument, 0, 'i'},
-	{"rpk", no_argument, 0, 'r'}, {"help", no_argument, 0, '0'},
-	{"private-key", required_argument, 0, '1'},
-	{"public-key", required_argument, 0, '2'},
-	{"peer-public-key", required_argument, 0, '3'},
-	{"verify-peer", required_argument, 0, '4'},
-	{"ip", required_argument, 0, 'a'}, {"port", required_argument, 0, 'b'},
-	{"ima", optional_argument, 0, 'm'}, {0}};
+        {"verbose", no_argument, 0, 'v'},
+        {"log-level", required_argument, 0, 'l'},
+        {"coap-log-level", required_argument, 0, 'c'},
+        {"timeout", required_argument, 0, 't'},
+        {"pcr-file", required_argument, 0, 'f'},
+        {"pcr-selection", required_argument, 0, 's'},
+        {"psk", no_argument, 0, 'p'}, {"key", required_argument, 0, 'k'},
+        {"identity", required_argument, 0, 'i'}, {"rpk", no_argument, 0, 'r'},
+        {"help", no_argument, 0, '0'},
+        {"private-key", required_argument, 0, '1'},
+        {"public-key", required_argument, 0, '2'},
+        {"peer-public-key", required_argument, 0, '3'},
+        {"verify-peer", required_argument, 0, '4'},
+        {"ip", required_argument, 0, 'a'}, {"port", required_argument, 0, 'b'},
+        {"ima", optional_argument, 0, 'm'}, {0}};
 
 static const struct option attester_options[] = {
-	{"verbose", no_argument, 0, 'v'}, {"log-level", required_argument, 0, 'l'},
-	{"coap-log-level", required_argument, 0, 'c'}, {"psk", no_argument, 0, 'p'},
-	{"key", required_argument, 0, 'k'}, {"hint", required_argument, 0, 'h'},
-	{"rpk", no_argument, 0, 'r'}, {"help", no_argument, 0, '0'},
-	{"private-key", required_argument, 0, '1'},
-	{"public-key", required_argument, 0, '2'},
-	{"peer-public-key", required_argument, 0, '3'},
-	{"verify-peer", required_argument, 0, '4'},
-	{"port", required_argument, 0, 'b'}, {0}};
+        {"verbose", no_argument, 0, 'v'},
+        {"log-level", required_argument, 0, 'l'},
+        {"coap-log-level", required_argument, 0, 'c'},
+        {"psk", no_argument, 0, 'p'}, {"key", required_argument, 0, 'k'},
+        {"hint", required_argument, 0, 'h'}, {"rpk", no_argument, 0, 'r'},
+        {"help", no_argument, 0, '0'},
+        {"private-key", required_argument, 0, '1'},
+        {"public-key", required_argument, 0, '2'},
+        {"peer-public-key", required_argument, 0, '3'},
+        {"verify-peer", required_argument, 0, '4'},
+        {"port", required_argument, 0, 'b'}, {0}};
 
 int parse_command_line_arguments(int argc, char** argv, cli_config* variables) {
-	cli_parser_caller caller = variables->caller;
-	char* log_name;
-	if (caller == VERIFIER) {
-		log_name = "verifier";
-	} else {
-		log_name = "attester";
-	}
-	for (;;) {
-		int index = -1;
-		int identifier = getopt_long(argc, argv,
-			((caller == VERIFIER) ? "vl:c:t:f:s:pk:i:r" : "vl:c:pk:h:r"),
-			((caller == VERIFIER) ? verifier_options : attester_options),
-			&index);
+    cli_parser_caller caller = variables->caller;
+    char* log_name;
+    if (caller == VERIFIER) {
+        log_name = "verifier";
+    } else {
+        log_name = "attester";
+    }
+    for (;;) {
+        int index = -1;
+        int identifier = getopt_long(argc, argv,
+                ((caller == VERIFIER) ? "vl:c:t:f:s:pk:i:r" : "vl:c:pk:h:r"),
+                ((caller == VERIFIER) ? verifier_options : attester_options),
+                &index);
 
-		if (identifier == -1)
-			return 0; // end of command line arguments reached
+        if (identifier == -1) {
+            return 0;  // end of command line arguments reached
+        } else if (identifier == '0' || identifier == '?') {
+            // print help message
+            printf("\nUsage: %s [OPTIONS]\n", log_name);
+            printf("     --help:                     Print this help "
+                   "message.\n");
+            printf(" -v, --verbose:                  Set CHARRA and CoAP "
+                   "log-level to DEBUG.\n");
+            printf(" -l, --log-level=LEVEL:          Set CHARRA log-level to "
+                   "LEVEL. Available are: TRACE, DEBUG, INFO, WARN, ERROR, "
+                   "FATAL. Default is INFO.\n");
+            printf(" -c, --coap-log-level=LEVEL:     Set CoAP log-level to "
+                   "LEVEL. Available are: DEBUG, INFO, NOTICE, WARNING, ERR, "
+                   "CRIT, ALERT, EMERG, CIPHERS. Default is INFO.\n");
+            if (caller == VERIFIER) {
+                printf("     --ip=IP:                    Connect to IP instead "
+                       "of doing the attestation on localhost.\n");
+                printf("     --port=PORT:                Connect to PORT "
+                       "instead of default port %u.\n",
+                        *(variables->common_config.port));
+                printf(" -t, --timeout=SECONDS:          Wait up to SECONDS "
+                       "for the attestation answer. Default is %d seconds.\n",
+                        *(variables->verifier_config.timeout));
+                printf(" -f, --pcr-file=PATH:            Read reference PCRs "
+                       "from PATH. Default path is '%s'\n",
+                        *(variables->verifier_config.reference_pcr_file_path));
+                printf(" -s, --pcr-selection=X1[,X2...]: Specifies which PCRs "
+                       "to check on the attester. Each X references one PCR. "
+                       "PCR numbers shall be ordered from smallest to biggest, "
+                       "comma-seperated\n");
+                printf("                                 and without "
+                       "whitespace. By default these PCRs are checked: ");
+                for (uint32_t i = 0;
+                        i < *variables->verifier_config.tpm_pcr_selection_len;
+                        i++) {
+                    printf("%d",
+                            variables->verifier_config.tpm_pcr_selection[i]);
+                    if (i != *variables->verifier_config.tpm_pcr_selection_len -
+                                     1) {
+                        printf(", ");
+                    }
+                }
 
-		else if (identifier == '0' || identifier == '?') {
-			// print help message
-			printf("\nUsage: %s [OPTIONS]\n", log_name);
-			printf(
-				"     --help:                     Print this help message.\n");
-			printf(" -v, --verbose:                  Set CHARRA and CoAP "
-				   "log-level "
-				   "to DEBUG.\n");
-			printf(" -l, --log-level=LEVEL:          Set CHARRA log-level to "
-				   "LEVEL. "
-				   "Available are: TRACE, DEBUG, INFO, WARN, ERROR, FATAL. "
-				   "Default is INFO.\n");
-			printf(
-				" -c, --coap-log-level=LEVEL:     Set CoAP log-level to LEVEL. "
-				"Available are: DEBUG, INFO, NOTICE, WARNING, ERR, CRIT, "
-				"ALERT, EMERG, CIPHERS. Default is INFO.\n");
-			if (caller == VERIFIER) {
-				printf(
-					"     --ip=IP:                    Connect to IP instead of "
-					"doing the attestation on localhost.\n");
-				printf(
-					"     --port=PORT:                Connect to PORT instead "
-					"of default port %d.\n",
-					*(variables->common_config.port));
-				printf(
-					" -t, --timeout=SECONDS:          Wait up to SECONDS for "
-					"the attestation answer. Default is %d seconds.\n",
-					*(variables->verifier_config.timeout));
-				printf(
-					" -f, --pcr-file=PATH:            Read reference PCRs from "
-					"PATH. Default path is '%s'\n",
-					*(variables->verifier_config.reference_pcr_file_path));
-				printf(" -s, --pcr-selection=X1[,X2...]: Specifies which "
-					   "PCRs to check on the attester. Each X references one "
-					   "PCR. PCR numbers shall be ordered from smallest to "
-					   "biggest, comma-seperated\n");
-				printf("                                 and without "
-					   "whitespace. By default these PCRs are checked: ");
-				for (uint32_t i = 0;
-					 i < *variables->verifier_config.tpm_pcr_selection_len;
-					 i++) {
-					printf(
-						"%d", variables->verifier_config.tpm_pcr_selection[i]);
-					if (i !=
-						*variables->verifier_config.tpm_pcr_selection_len - 1) {
-						printf(", ");
-					}
-				}
-				printf("\n");
-				printf(
-					"     --ima[=PATH]:               Request the attester to "
-					"include an IMA event log in the attestation response. "
-					"By default IMA requests the file\n");
-				printf(
-					"                                 '%s'. Alternatives can "
-					"be "
-					"passed.\n",
-					*(variables->verifier_config.ima_event_log_path));
-				printf("DTLS-PSK Options:\n");
-				printf(
-					" -p, --psk:                      Enable DTLS protocol "
-					"with PSK. "
-					"By default the key '%s' and identity '%s' are used.\n",
-					*variables->common_config.dtls_psk_key,
-					*variables->verifier_config.dtls_psk_identity);
-				printf(" -k, --key=KEY:                  Use KEY as pre-shared "
-					   "key for DTLS-PSK. Implicitly enables DTLS-PSK.\n");
-				printf(
-					" -i, --identity=IDENTITY:        Use IDENTITY as identity "
-					"for DTLS. Implicitly enables DTLS-PSK.\n");
-			} else {
-				printf("     --port=PORT:                Open PORT instead of "
-					   "port "
-					   "%d.\n",
-					*(variables->common_config.port));
-				printf("DTLS-PSK Options:\n");
-				printf(" -p, --psk:                      Enable DTLS protocol "
-					   "with PSK. "
-					   "By default the key '%s' and hint '%s' are used.\n",
-					*variables->common_config.dtls_psk_key,
-					*variables->attester_config.dtls_psk_hint);
-				printf(" -k, --key=KEY:                  Use KEY as pre-shared "
-					   "key for DTLS. Implicitly enables DTLS-PSK.\n");
-				printf(" -h, --hint=HINT:                Use HINT as hint for "
-					   "DTLS. Implicitly enables DTLS-PSK.\n");
-			}
-			printf("DTLS-RPK Options:\n");
-			printf("                                 Charra includes default "
-				   "'keys' in the keys folder, but these are only intended for "
-				   "testing. They MUST be changed in actual production "
-				   "environments!\n");
-			printf(" -r, --rpk:                      Enable DTLS-RPK (raw "
-				   "public keys) protocol . The protocol is intended for "
-				   "scenarios in which public keys of either attester or "
-				   "verifier or both of them are pre-shared.\n");
-			printf(
-				"     --private-key=PATH:         Specify the path of the "
-				"private key used for RPK. Currently only supports DER (ASN.1) "
-				"format.\n");
-			printf("                                 By default '%s' is used. "
-				   "Implicitly enables DTLS-RPK.\n",
-				*variables->common_config.dtls_rpk_private_key_path);
-			printf(
-				"     --public-key=PATH:          Specify the path of the "
-				"public key used for RPK. Currently only supports DER (ASN.1) "
-				"format.\n");
-			printf("                                 By default '%s' is used. "
-				   "Implicitly enables DTLS-RPK.\n",
-				*variables->common_config.dtls_rpk_public_key_path);
-			printf("     --peer-public-key=PATH:     Specify the path of the "
-				   "reference public key of the peer, used for RPK. Currently "
-				   "only supports DER (ASN.1) format.\n");
-			printf("                                 By default '%s' is used. "
-				   "Implicitly enables DTLS-RPK.\n",
-				*variables->common_config.dtls_rpk_peer_public_key_path);
-			printf("     --verify-peer=[0,1]:        Specify whether the peers "
-				   "public key shall be checked against the reference public "
-				   "key. 0 means no check, 1 means check. By default the check "
-				   "is performed.\n");
-			printf("                                 WARNING: Disabling the "
-				   "verification means that connections from any peer will be "
-				   "accepted. This is primarily intended for the verifier, "
-				   "which may not have\n");
-			printf("                                 the public keys of all "
-				   "attesters and does an identity check with the attestation "
-				   "response. Implicitly enables DTLS-RPK.\n");
-			printf("\nTo specify TCTI commands for the TPM, set the "
-				   "'CHARRA_TCTI' environment variable accordingly.\n");
+                printf("\n");
+                printf("     --ima[=PATH]:               Request the attester "
+                       "to include an IMA event log in the attestation "
+                       "response. By default IMA requests the file\n");
+                printf("                                 '%s'. Alternatives "
+                       "can be passed.\n",
+                        *(variables->verifier_config.ima_event_log_path));
+                printf("DTLS-PSK Options:\n");
+                printf(" -p, --psk:                      Enable DTLS protocol "
+                       "with PSK. By default the key '%s' and identity '%s' "
+                       "are used.\n",
+                        *variables->common_config.dtls_psk_key,
+                        *variables->verifier_config.dtls_psk_identity);
+                printf(" -k, --key=KEY:                  Use KEY as pre-shared "
+                       "key for DTLS-PSK. Implicitly enables DTLS-PSK.\n");
+                printf(" -i, --identity=IDENTITY:        Use IDENTITY as "
+                       "identity for DTLS. Implicitly enables DTLS-PSK.\n");
+            } else {
+                printf("     --port=PORT:                Open PORT instead of "
+                       "port %u.\n",
+                        *(variables->common_config.port));
+                printf("DTLS-PSK Options:\n");
+                printf(" -p, --psk:                      Enable DTLS protocol "
+                       "with PSK. By default the key '%s' and hint '%s' are "
+                       "used.\n",
+                        *variables->common_config.dtls_psk_key,
+                        *variables->attester_config.dtls_psk_hint);
+                printf(" -k, --key=KEY:                  Use KEY as pre-shared "
+                       "key for DTLS. Implicitly enables DTLS-PSK.\n");
+                printf(" -h, --hint=HINT:                Use HINT as hint for "
+                       "DTLS. Implicitly enables DTLS-PSK.\n");
+            }
+            printf("DTLS-RPK Options:\n");
+            printf("                                 Charra includes default "
+                   "'keys' in the keys folder, but these are only intended for "
+                   "testing. They MUST be changed in actual production "
+                   "environments!\n");
+            printf(" -r, --rpk:                      Enable DTLS-RPK (raw "
+                   "public keys) protocol . The protocol is intended for "
+                   "scenarios in which public keys of either attester or "
+                   "verifier or both of them are pre-shared.\n");
+            printf("     --private-key=PATH:         Specify the path of the "
+                   "private key used for RPK. Currently only supports DER "
+                   "(ASN.1) format.\n");
+            printf("                                 By default '%s' is used. "
+                   "Implicitly enables DTLS-RPK.\n",
+                    *variables->common_config.dtls_rpk_private_key_path);
+            printf("     --public-key=PATH:          Specify the path of the "
+                   "public key used for RPK. Currently only supports DER "
+                   "(ASN.1) format.\n");
+            printf("                                 By default '%s' is used. "
+                   "Implicitly enables DTLS-RPK.\n",
+                    *variables->common_config.dtls_rpk_public_key_path);
+            printf("     --peer-public-key=PATH:     Specify the path of the "
+                   "reference public key of the peer, used for RPK. Currently "
+                   "only supports DER (ASN.1) format.\n");
+            printf("                                 By default '%s' is used. "
+                   "Implicitly enables DTLS-RPK.\n",
+                    *variables->common_config.dtls_rpk_peer_public_key_path);
+            printf("     --verify-peer=[0,1]:        Specify whether the peers "
+                   "public key shall be checked against the reference public "
+                   "key. 0 means no check, 1 means check. By default the check "
+                   "is performed.\n");
+            printf("                                 WARNING: Disabling the "
+                   "verification means that connections from any peer will be "
+                   "accepted. This is primarily intended for the verifier, "
+                   "which may not have\n");
+            printf("                                 the public keys of all "
+                   "attesters and does an identity check with the attestation "
+                   "response. Implicitly enables DTLS-RPK.\n");
+            printf("\nTo specify TCTI commands for the TPM, set the "
+                   "'CHARRA_TCTI' environment variable accordingly.\n");
 
-			// return -1 if argument could not be parsed, 1 if help message was
-			// called via parameter
-			return (identifier == '?') ? -1 : 1;
-		}
+            /*
+             * return -1 if argument could not be parsed, and 1 if help message
+             * was called via argument.
+             */
+            return (identifier == '?') ? -1 : 1;
+        } else if (identifier == 'v') {  // verbose logging
+            *(variables->common_config.charra_log_level) = CHARRA_LOG_DEBUG;
+            *(variables->common_config.coap_log_level) = LOG_DEBUG;
+            continue;
+        } else if (identifier == 'l') {  // CHARRA log level
+            int result = charra_log_level_from_str(
+                    optarg, variables->common_config.charra_log_level);
+            if (result != 0) {
+                charra_log_error("[%s] Error while parsing '-l/--log-level': "
+                                 "Unrecognized argument %s",
+                        log_name, optarg);
+                return -1;
+            }
+            continue;
+        } else if (identifier == 'c') {  // libcoap log level
+            int result = charra_coap_log_level_from_str(
+                    optarg, variables->common_config.coap_log_level);
+            if (result != 0) {
+                charra_log_error(
+                        "[%s] Error while parsing '-c/--coap-log-level': "
+                        "Unrecognized argument %s",
+                        log_name, optarg);
+                return -1;
+            }
+            continue;
+        } else if (identifier == 'b') {  // port
+            char* end;
+            *(variables->common_config.port) =
+                    (unsigned int)strtoul(optarg, &end, 10);
+            if (*(variables->common_config.port) == 0 || end == optarg) {
+                charra_log_error(
+                        "[%s] Error while parsing '--port': Port could not be "
+                        "parsed",
+                        log_name);
+                return -1;
+            }
+            continue;
+        } else if (identifier == 'p') {  // use DTLS PSK
+            *variables->common_config.use_dtls_psk = true;
+            continue;
+        } else if (identifier == 'k') {  // DTLS PSK key
+            *variables->common_config.use_dtls_psk = true;
+            uint32_t length = strlen(optarg);
+            char* key = malloc(length * sizeof(char));
+            strcpy(key, optarg);
+            *(variables->common_config.dtls_psk_key) = key;
+            continue;
+        } else if (identifier == 'r') {  // use DTLS RPK
+            *variables->common_config.use_dtls_rpk = true;
+            continue;
+        } else if (identifier == '1') {  // DTLS RPK private key
+            *variables->common_config.use_dtls_rpk = true;
+            char* path = malloc(strlen(optarg));
+            strcpy(path, optarg);
+            if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
+                *(variables->common_config.dtls_rpk_private_key_path) = path;
+                continue;
+            } else {
+                charra_log_error(
+                        "[%s] DTLS-RPK: private key file '%s' does not exist.",
+                        log_name, path);
+                return -1;
+            }
+        } else if (identifier == '2') {
+            *variables->common_config.use_dtls_rpk = true;
+            char* path = malloc(strlen(optarg));
+            strcpy(path, optarg);
+            if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
+                *(variables->common_config.dtls_rpk_public_key_path) = path;
+                continue;
+            } else {
+                charra_log_error(
+                        "[%s] DTLS-RPK: public key file '%s' does not exist.",
+                        log_name, path);
+                return -1;
+            }
+        } else if (identifier == '3') {
+            *variables->common_config.use_dtls_rpk = true;
+            char* path = malloc(strlen(optarg));
+            strcpy(path, optarg);
+            if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
+                *(variables->common_config.dtls_rpk_peer_public_key_path) =
+                        path;
+                continue;
+            } else {
+                charra_log_error("[%s] DTLS-RPK: peers' public key file '%s' "
+                                 "does not exist.",
+                        log_name, path);
+                return -1;
+            }
+        } else if (identifier == '4') {
+            if (strcmp("0", optarg) == 0) {
+                *variables->common_config.dtls_rpk_verify_peer_public_key =
+                        false;
+            } else if (strcmp("1", optarg) == 0) {
+                *variables->common_config.dtls_rpk_verify_peer_public_key =
+                        true;
+            } else {
+                charra_log_error("[%s] Error while parsing '--verify-peer': "
+                                 "'%s' could not be parsed as 0 or 1.",
+                        log_name, optarg);
+                return -1;
+            }
+            continue;
+        }
 
-		else if (identifier == 'v') { // verbose logging
-			*(variables->common_config.charra_log_level) = CHARRA_LOG_DEBUG;
-			*(variables->common_config.coap_log_level) = LOG_DEBUG;
-			continue;
-		}
-
-		else if (identifier == 'l') { // set log level for charra
-			int result = charra_log_level_from_str(
-				optarg, variables->common_config.charra_log_level);
-			if (result != 0) {
-				charra_log_error("[%s] Error while parsing '-l/--log-level': "
-								 "Unrecognized argument %s",
-					log_name, optarg);
-				return -1;
-			}
-			continue;
-		}
-
-		else if (identifier == 'c') { // set log level for libcoap
-			int result = charra_coap_log_level_from_str(
-				optarg, variables->common_config.coap_log_level);
-			if (result != 0) {
-				charra_log_error(
-					"[%s] Error while parsing '-c/--coap-log-level': "
-					"Unrecognized argument %s",
-					log_name, optarg);
-				return -1;
-			}
-			continue;
-		}
-
-		else if (identifier == 'b') { // set port
-			char* end;
-			*(variables->common_config.port) =
-				(unsigned int)strtoul(optarg, &end, 10);
-			if (*(variables->common_config.port) == 0 || end == optarg) {
-				charra_log_error(
-					"[%s] Error while parsing '--port': Port could not be "
-					"parsed",
-					log_name);
-				return -1;
-			}
-			continue;
-		}
-
-		else if (identifier == 'p') {
-			*variables->common_config.use_dtls_psk = true;
-			continue;
-		}
-
-		else if (identifier == 'k') {
-			*variables->common_config.use_dtls_psk = true;
-			uint32_t length = strlen(optarg);
-			char* key = malloc(length * sizeof(char));
-			strcpy(key, optarg);
-			*(variables->common_config.dtls_psk_key) = key;
-			continue;
-		}
-
-		else if (identifier == 'r') {
-			*variables->common_config.use_dtls_rpk = true;
-			continue;
-		}
-
-		else if (identifier == '1') {
-			*variables->common_config.use_dtls_rpk = true;
-			char* path = malloc(strlen(optarg));
-			strcpy(path, optarg);
-			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
-				*(variables->common_config.dtls_rpk_private_key_path) = path;
-				continue;
-			} else {
-				charra_log_error(
-					"[%s] DTLS-RPK: private key file '%s' does not exist.",
-					log_name, path);
-				return -1;
-			}
-		}
-
-		else if (identifier == '2') {
-			*variables->common_config.use_dtls_rpk = true;
-			char* path = malloc(strlen(optarg));
-			strcpy(path, optarg);
-			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
-				*(variables->common_config.dtls_rpk_public_key_path) = path;
-				continue;
-			} else {
-				charra_log_error(
-					"[%s] DTLS-RPK: public key file '%s' does not exist.",
-					log_name, path);
-				return -1;
-			}
-		}
-
-		else if (identifier == '3') {
-			*variables->common_config.use_dtls_rpk = true;
-			char* path = malloc(strlen(optarg));
-			strcpy(path, optarg);
-			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
-				*(variables->common_config.dtls_rpk_peer_public_key_path) =
-					path;
-				continue;
-			} else {
-				charra_log_error("[%s] DTLS-RPK: peers' public key file '%s' "
-								 "does not exist.",
-					log_name, path);
-				return -1;
-			}
-		}
-
-		else if (identifier == '4') {
-			if (strcmp("0", optarg) == 0) {
-				*variables->common_config.dtls_rpk_verify_peer_public_key =
-					false;
-			} else if (strcmp("1", optarg) == 0) {
-				*variables->common_config.dtls_rpk_verify_peer_public_key =
-					true;
-			} else {
-				charra_log_error("[%s] Error while parsing '--verify-peer': "
-								 "'%s' could not be parsed as 0 or 1.",
-					log_name, optarg);
-				return -1;
-			}
-			continue;
-		}
-
-		if (caller == VERIFIER && identifier == 'a') { // set IP address
-			int argument_length = strlen(optarg);
-			if (argument_length > 15) {
-				charra_log_error(
-					"[%s] Error while parsing '--ip': Input too long "
-					"for IPv4 address",
-					log_name);
-				return -1;
-			}
-			strncpy(variables->verifier_config.dst_host, optarg, 16);
-			continue;
-		}
-
-		else if (caller == VERIFIER && identifier == 't') {
-			char* end;
-			*(variables->verifier_config.timeout) =
-				(uint16_t)strtoul(optarg, &end, 10);
-			if (*(variables->verifier_config.timeout) == 0 || end == optarg) {
-				charra_log_error(
-					"[%s] Error while parsing '--port': Port could not "
-					"be parsed",
-					log_name);
-				return -1;
-			}
-			continue;
-		}
-
-		else if (caller == VERIFIER && identifier == 'f') {
-			uint32_t length = strlen(optarg);
-			char* path = malloc(length * sizeof(char));
-			strcpy(path, optarg);
-			if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
-				*(variables->verifier_config.reference_pcr_file_path) = path;
-				continue;
-			} else {
-				charra_log_error(
-					"[%s] Reference PCR file ''%s' does not exist.", log_name,
-					path);
-				return -1;
-			}
-		}
-
-		else if (caller == VERIFIER && identifier == 's') {
-			uint32_t length = strlen(optarg);
-			uint8_t* tpm_pcr_selection =
-				variables->verifier_config.tpm_pcr_selection;
-			uint32_t* tpm_pcr_selection_len =
-				variables->verifier_config.tpm_pcr_selection_len;
-			for (uint32_t i = 0; i < *tpm_pcr_selection_len; i++) {
-				tpm_pcr_selection[i] = 0; // overwrite static config with zeros
-										  // in case CLI config uses less PCRs
-			}
-			*tpm_pcr_selection_len = 0;
-			char* number_start = optarg;
-			int last_number = -1;
-			do {
-				char* end = NULL;
-				errno = 0;
-				uint32_t number = strtoul(number_start, &end, 10);
-				if (end == number_start || errno != 0) {
-					charra_log_error("[%s] PCR selection could not be "
-									 "parsed, parse error at '%s'",
-						log_name, number_start);
-					return -1;
-				} else if (number >= TPM2_MAX_PCRS) {
-					charra_log_error(
-						"[%s] One PCR from the PCR selection was parsed as "
-						"%d, but the TPM2 only has PCRs up to %d.",
-						log_name, number, TPM2_MAX_PCRS - 1);
-					return -1;
-				} else if ((int)number <= last_number) {
-					charra_log_error(
-						"[%s] PCR selection was detected to not be ordered "
-						"from smallest to biggest. Last parsed number %d "
-						"is bigger or equal to current number %d.",
-						log_name, last_number, number);
-					return -1;
-				}
-				number_start = end + 1;
-				tpm_pcr_selection[*tpm_pcr_selection_len] = number;
-				(*tpm_pcr_selection_len)++;
-				last_number = number;
-			} while (number_start < optarg + length);
-			continue;
-		}
-
-		else if (caller == VERIFIER && identifier == 'i') {
-			*variables->common_config.use_dtls_psk = true;
-			uint32_t length = strlen(optarg);
-			char* identity = malloc(length * sizeof(char));
-			strcpy(identity, optarg);
-			*(variables->verifier_config.dtls_psk_identity) = identity;
-			continue;
-		}
-
-		else if (caller == VERIFIER &&
-				 identifier == 'm') { // enable request for IMA event log
-			*(variables->verifier_config.use_ima_event_log) = true;
-			if (optarg != NULL) {
-				*(variables->verifier_config.ima_event_log_path) =
-					malloc(strlen(optarg) + 1);
-				strncpy(*(variables->verifier_config.ima_event_log_path),
-					optarg, strlen(optarg));
-			}
-		}
-
-		else if (caller == ATTESTER && identifier == 'n') {
-			*variables->common_config.use_dtls_psk = true;
-			uint32_t length = strlen(optarg);
-			char* hint = malloc(length * sizeof(char));
-			strcpy(hint, optarg);
-			*(variables->attester_config.dtls_psk_hint) = hint;
-			continue;
-		}
-
-		else {
-			// undefined behaviour, probably because getopt_long returned an
-			// identifier which is not checked here
-			charra_log_error(
-				"[%s] Error: Undefined behaviour while parsing command line",
-				log_name);
-			return -1;
-		}
-	}
+        if (caller == VERIFIER && identifier == 'a') {  // set IP address
+            int argument_length = strlen(optarg);
+            if (argument_length > 15) {
+                charra_log_error(
+                        "[%s] Error while parsing '--ip': Input too long "
+                        "for IPv4 address",
+                        log_name);
+                return -1;
+            }
+            strncpy(variables->verifier_config.dst_host, optarg, 16);
+            continue;
+        } else if (caller == VERIFIER && identifier == 't') {
+            char* end;
+            *(variables->verifier_config.timeout) =
+                    (uint16_t)strtoul(optarg, &end, 10);
+            if (*(variables->verifier_config.timeout) == 0 || end == optarg) {
+                charra_log_error("[%s] Error while parsing '--port': Port "
+                                 "could not be parsed",
+                        log_name);
+                return -1;
+            }
+            continue;
+        } else if (caller == VERIFIER && identifier == 'f') {
+            uint32_t length = strlen(optarg);
+            char* path = malloc(length * sizeof(char));
+            strcpy(path, optarg);
+            if (charra_io_file_exists(path) == CHARRA_RC_SUCCESS) {
+                *(variables->verifier_config.reference_pcr_file_path) = path;
+                continue;
+            } else {
+                charra_log_error(
+                        "[%s] Reference PCR file ''%s' does not exist.",
+                        log_name, path);
+                return -1;
+            }
+        } else if (caller == VERIFIER && identifier == 's') {
+            uint32_t length = strlen(optarg);
+            uint8_t* tpm_pcr_selection =
+                    variables->verifier_config.tpm_pcr_selection;
+            uint32_t* tpm_pcr_selection_len =
+                    variables->verifier_config.tpm_pcr_selection_len;
+            for (uint32_t i = 0; i < *tpm_pcr_selection_len; i++) {
+                /*
+                 * overwrite static config with zeros in case CLI config uses
+                 * less PCRs
+                 */
+                tpm_pcr_selection[i] = 0;
+            }
+            *tpm_pcr_selection_len = 0;
+            char* number_start = optarg;
+            int last_number = -1;
+            do {
+                char* end = NULL;
+                errno = 0;
+                uint32_t number = strtoul(number_start, &end, 10);
+                if (end == number_start || errno != 0) {
+                    charra_log_error("[%s] PCR selection could not be parsed, "
+                                     "parse error at '%s'",
+                            log_name, number_start);
+                    return -1;
+                } else if (number >= TPM2_MAX_PCRS) {
+                    charra_log_error(
+                            "[%s] One PCR from the PCR selection was parsed as "
+                            "%d, but the TPM2 only has PCRs up to %d.",
+                            log_name, number, TPM2_MAX_PCRS - 1);
+                    return -1;
+                } else if ((int)number <= last_number) {
+                    charra_log_error(
+                            "[%s] PCR selection was detected to not be ordered "
+                            "from smallest to biggest. Last parsed number %d "
+                            "is bigger or equal to current number %d.",
+                            log_name, last_number, number);
+                    return -1;
+                }
+                number_start = end + 1;
+                tpm_pcr_selection[*tpm_pcr_selection_len] = number;
+                (*tpm_pcr_selection_len)++;
+                last_number = number;
+            } while (number_start < optarg + length);
+            continue;
+        } else if (caller == VERIFIER && identifier == 'i') {
+            *variables->common_config.use_dtls_psk = true;
+            uint32_t length = strlen(optarg);
+            char* identity = malloc(length * sizeof(char));
+            strcpy(identity, optarg);
+            *(variables->verifier_config.dtls_psk_identity) = identity;
+            continue;
+        } else if (caller == VERIFIER &&
+                   identifier == 'm') {  // enable request for IMA event log
+            *(variables->verifier_config.use_ima_event_log) = true;
+            if (optarg != NULL) {
+                *(variables->verifier_config.ima_event_log_path) =
+                        malloc(strlen(optarg) + 1);
+                strncpy(*(variables->verifier_config.ima_event_log_path),
+                        optarg, strlen(optarg));
+            }
+        } else if (caller == ATTESTER && identifier == 'n') {
+            *variables->common_config.use_dtls_psk = true;
+            uint32_t length = strlen(optarg);
+            char* hint = malloc(length * sizeof(char));
+            strcpy(hint, optarg);
+            *(variables->attester_config.dtls_psk_hint) = hint;
+            continue;
+        } else {
+            // undefined behaviour, probably because getopt_long returned an
+            // identifier which is not checked here
+            charra_log_error("[%s] Error: Undefined behaviour while parsing "
+                             "command line",
+                    log_name);
+            return -1;
+        }
+    }
 }

--- a/src/util/cli_util.h
+++ b/src/util/cli_util.h
@@ -23,8 +23,8 @@
 #include <stdbool.h>
 
 typedef enum {
-	VERIFIER,
-	ATTESTER,
+    VERIFIER,
+    ATTESTER,
 } cli_parser_caller;
 
 /**
@@ -32,16 +32,16 @@ typedef enum {
  * which might geht modified by the CLI parser
  */
 typedef struct {
-	charra_log_t* charra_log_level;
-	coap_log_t* coap_log_level;
-	unsigned int* port;
-	bool* use_dtls_psk;
-	char** dtls_psk_key;
-	bool* use_dtls_rpk;
-	char** dtls_rpk_private_key_path;
-	char** dtls_rpk_public_key_path;
-	char** dtls_rpk_peer_public_key_path;
-	bool* dtls_rpk_verify_peer_public_key;
+    charra_log_t* charra_log_level;
+    coap_log_t* coap_log_level;
+    unsigned int* port;
+    bool* use_dtls_psk;
+    char** dtls_psk_key;
+    bool* use_dtls_rpk;
+    char** dtls_rpk_private_key_path;
+    char** dtls_rpk_public_key_path;
+    char** dtls_rpk_peer_public_key_path;
+    bool* dtls_rpk_verify_peer_public_key;
 } cli_config_common;
 
 /**
@@ -49,7 +49,7 @@ typedef struct {
  * which might geht modified by the CLI parser
  */
 typedef struct {
-	char** dtls_psk_hint;
+    char** dtls_psk_hint;
 } cli_config_attester;
 
 /**
@@ -57,14 +57,14 @@ typedef struct {
  * which might geht modified by the CLI parser
  */
 typedef struct {
-	char* dst_host;
-	uint16_t* timeout;
-	char** reference_pcr_file_path;
-	uint8_t* tpm_pcr_selection;
-	uint32_t* tpm_pcr_selection_len;
-	bool* use_ima_event_log;
-	char** ima_event_log_path;
-	char** dtls_psk_identity;
+    char* dst_host;
+    uint16_t* timeout;
+    char** reference_pcr_file_path;
+    uint8_t* tpm_pcr_selection;
+    uint32_t* tpm_pcr_selection_len;
+    bool* use_ima_event_log;
+    char** ima_event_log_path;
+    char** dtls_psk_identity;
 } cli_config_verifier;
 
 /**
@@ -72,10 +72,10 @@ typedef struct {
  * modified by the CLI parser
  */
 typedef struct {
-	cli_parser_caller caller;
-	cli_config_common common_config;
-	cli_config_attester attester_config;
-	cli_config_verifier verifier_config;
+    cli_parser_caller caller;
+    cli_config_common common_config;
+    cli_config_attester attester_config;
+    cli_config_verifier verifier_config;
 } cli_config;
 
 /**
@@ -84,7 +84,7 @@ typedef struct {
 * @param argc The number of arguments which were given to the CLI.
 * @param argv The arguments which were given to the CLI.
 * @param variables A struct holding a caller identifier and pointers to config
-				   variables which might get modified depending on the CLI
+                   variables which might get modified depending on the CLI
 arguments.
 * @return 0 on success, -1 on parse error, 1 when help message was displayed
 */

--- a/src/util/coap_util.c
+++ b/src/util/coap_util.c
@@ -31,273 +31,275 @@
 #define LOG_NAME "coap-util"
 #define CHARRA_UNUSED __attribute__((unused))
 
-static const char* const coap_level_names[10] = {[LOG_EMERG] = "EMERG",
-	[LOG_ALERT] = "ALERT",
-	[LOG_CRIT] = "CRIT",
-	[LOG_ERR] = "ERR",
-	[LOG_WARNING] = "WARNING",
-	[LOG_NOTICE] = "NOTICE",
-	[LOG_INFO] = "INFO",
-	[LOG_DEBUG] = "DEBUG",
-	[COAP_LOG_CIPHERS] = "CIPHERS"};
+static const char* const coap_level_names[10] = {
+        [LOG_EMERG] = "EMERG",
+        [LOG_ALERT] = "ALERT",
+        [LOG_CRIT] = "CRIT",
+        [LOG_ERR] = "ERR",
+        [LOG_WARNING] = "WARNING",
+        [LOG_NOTICE] = "NOTICE",
+        [LOG_INFO] = "INFO",
+        [LOG_DEBUG] = "DEBUG",
+        [COAP_LOG_CIPHERS] = "CIPHERS",
+};
 
 /* --- function forward declarations -------------------------------------- */
 
 static int verify_rpk_peer_callback(const char* cn,
-	const uint8_t* asn1_public_cert, size_t asn1_length,
-	coap_session_t* session, unsigned depth, int validated, void* arg);
+        const uint8_t* asn1_public_cert, size_t asn1_length,
+        coap_session_t* session, unsigned depth, int validated, void* arg);
 
 /* --- function definitions ----------------------------------------------- */
 
 coap_context_t* charra_coap_new_context(const bool enable_coap_block_mode) {
-	/* startup */
-	coap_startup();
+    /* startup */
+    coap_startup();
 
-	/* create new context */
-	coap_context_t* coap_context = NULL;
-	if ((coap_context = coap_new_context(NULL)) != NULL) {
-		if (enable_coap_block_mode) {
-			/* enable block handling by libcoap */
-			coap_context_set_block_mode(
-				coap_context, COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
-		}
-	}
+    /* create new context */
+    coap_context_t* coap_context = NULL;
+    if ((coap_context = coap_new_context(NULL)) != NULL) {
+        if (enable_coap_block_mode) {
+            /* enable block handling by libcoap */
+            coap_context_set_block_mode(coap_context,
+                    COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+        }
+    }
 
-	return coap_context;
+    return coap_context;
 }
 
 coap_endpoint_t* charra_coap_new_endpoint(coap_context_t* coap_context,
-	const char* listen_address, const uint16_t port,
-	const coap_proto_t coap_protocol) {
-	/* prepare address */
-	coap_address_t addr = {0};
-	coap_address_init(&addr);
-	addr.addr.sin.sin_family = AF_INET;
-	inet_pton(AF_INET, listen_address, &addr.addr.sin.sin_addr);
-	addr.addr.sin.sin_port = htons(port);
+        const char* listen_address, const uint16_t port,
+        const coap_proto_t coap_protocol) {
+    /* prepare address */
+    coap_address_t addr = {0};
+    coap_address_init(&addr);
+    addr.addr.sin.sin_family = AF_INET;
+    inet_pton(AF_INET, listen_address, &addr.addr.sin.sin_addr);
+    addr.addr.sin.sin_port = htons(port);
 
-	/* create endpoint */
-	return coap_new_endpoint(coap_context, &addr, coap_protocol);
+    /* create endpoint */
+    return coap_new_endpoint(coap_context, &addr, coap_protocol);
 }
 
 coap_session_t* charra_coap_new_client_session(coap_context_t* coap_context,
-	const char* dest_address, const uint16_t port,
-	const coap_proto_t coap_protocol) {
-	/* prepare address */
-	coap_address_t addr = {0};
-	coap_address_init(&addr);
-	addr.addr.sin.sin_family = AF_INET;
-	inet_pton(AF_INET, dest_address, &addr.addr.sin.sin_addr);
-	addr.addr.sin.sin_port = htons(port);
+        const char* dest_address, const uint16_t port,
+        const coap_proto_t coap_protocol) {
+    /* prepare address */
+    coap_address_t addr = {0};
+    coap_address_init(&addr);
+    addr.addr.sin.sin_family = AF_INET;
+    inet_pton(AF_INET, dest_address, &addr.addr.sin.sin_addr);
+    addr.addr.sin.sin_port = htons(port);
 
-	/* create session */
-	return coap_new_client_session(coap_context, NULL, &addr, coap_protocol);
+    /* create session */
+    return coap_new_client_session(coap_context, NULL, &addr, coap_protocol);
 }
 
 coap_session_t* charra_coap_new_client_session_psk(coap_context_t* coap_context,
-	const char* dest_address, const uint16_t port,
-	const coap_proto_t coap_protocol, const char* identity, const uint8_t* key,
-	unsigned key_length) {
-	/* prepare address */
-	coap_address_t addr = {0};
-	coap_address_init(&addr);
-	addr.addr.sin.sin_family = AF_INET;
-	inet_pton(AF_INET, dest_address, &addr.addr.sin.sin_addr);
-	addr.addr.sin.sin_port = htons(port);
+        const char* dest_address, const uint16_t port,
+        const coap_proto_t coap_protocol, const char* identity,
+        const uint8_t* key, unsigned key_length) {
+    /* prepare address */
+    coap_address_t addr = {0};
+    coap_address_init(&addr);
+    addr.addr.sin.sin_family = AF_INET;
+    inet_pton(AF_INET, dest_address, &addr.addr.sin.sin_addr);
+    addr.addr.sin.sin_port = htons(port);
 
-	/* create session */
-	return coap_new_client_session_psk(
-		coap_context, NULL, &addr, coap_protocol, identity, key, key_length);
+    /* create session */
+    return coap_new_client_session_psk(coap_context, NULL, &addr, coap_protocol,
+            identity, key, key_length);
 }
 
 coap_session_t* charra_coap_new_client_session_pki(coap_context_t* coap_context,
-	const char* dest_address, const uint16_t port,
-	const coap_proto_t coap_protocol, coap_dtls_pki_t* dtls_pki) {
-	/* prepare address */
-	coap_address_t addr = {0};
-	coap_address_init(&addr);
-	addr.addr.sin.sin_family = AF_INET;
-	inet_pton(AF_INET, dest_address, &addr.addr.sin.sin_addr);
-	addr.addr.sin.sin_port = htons(port);
+        const char* dest_address, const uint16_t port,
+        const coap_proto_t coap_protocol, coap_dtls_pki_t* dtls_pki) {
+    /* prepare address */
+    coap_address_t addr = {0};
+    coap_address_init(&addr);
+    addr.addr.sin.sin_family = AF_INET;
+    inet_pton(AF_INET, dest_address, &addr.addr.sin.sin_addr);
+    addr.addr.sin.sin_port = htons(port);
 
-	/* create session */
-	return coap_new_client_session_pki(
-		coap_context, NULL, &addr, coap_protocol, dtls_pki);
+    /* create session */
+    return coap_new_client_session_pki(
+            coap_context, NULL, &addr, coap_protocol, dtls_pki);
 }
 
 coap_pdu_t* charra_coap_new_request(coap_session_t* session,
-	coap_message_t msg_type, coap_request_t method, coap_optlist_t** options,
-	const uint8_t* data, const size_t data_len) {
-	coap_pdu_t* pdu = NULL;
+        coap_message_t msg_type, coap_request_t method,
+        coap_optlist_t** options, const uint8_t* data, const size_t data_len) {
+    coap_pdu_t* pdu = NULL;
 
-	/* create new PDU */
-	if ((pdu = coap_new_pdu(session)) == NULL) {
-		charra_log_error("[" LOG_NAME "] Cannot create PDU");
-		goto error;
-	}
+    /* create new PDU */
+    if ((pdu = coap_new_pdu(session)) == NULL) {
+        charra_log_error("[" LOG_NAME "] Cannot create PDU");
+        goto error;
+    }
 
-	/* generate new message ID */
-	coap_message_id_t msg_id = coap_new_message_id(session);
+    /* generate new message ID */
+    coap_message_id_t msg_id = coap_new_message_id(session);
 
-	/* set up PDU */
-	pdu->type = msg_type;
-	pdu->mid = msg_id;
-	pdu->code = method;
+    /* set up PDU */
+    pdu->type = msg_type;
+    pdu->mid = msg_id;
+    pdu->code = method;
 
-	/* generate new token */
-	coap_token_t token = {0};
-	coap_session_new_token(session, &(token.length), token.data);
+    /* generate new token */
+    coap_token_t token = {0};
+    coap_session_new_token(session, &(token.length), token.data);
 
-	/* add token to PDU */
-	if (coap_add_token(pdu, token.length, token.data) == 0) {
-		charra_log_error("[" LOG_NAME "] Cannot add token to request");
-		goto error;
-	}
+    /* add token to PDU */
+    if (coap_add_token(pdu, token.length, token.data) == 0) {
+        charra_log_error("[" LOG_NAME "] Cannot add token to request");
+        goto error;
+    }
 
-	/* add options to PDU */
-	if (options != NULL) {
-		if (coap_add_optlist_pdu(pdu, options) == 0) {
-			charra_log_error("[" LOG_NAME "] Cannot add options to request");
-			goto error;
-		}
-	}
+    /* add options to PDU */
+    if (options != NULL) {
+        if (coap_add_optlist_pdu(pdu, options) == 0) {
+            charra_log_error("[" LOG_NAME "] Cannot add options to request");
+            goto error;
+        }
+    }
 
-	/* add (large) data to PDU */
-	if (data_len > 0) {
-		/* let the underlying libcoap decide how this data should be sent */
-		if (coap_add_data_large_request(
-				session, pdu, data_len, data, NULL, NULL) == 0) {
-			charra_log_error(
-				"[" LOG_NAME
-				"] Cannot add (large) data option list to request");
-			goto error;
-		}
-	}
+    /* add (large) data to PDU */
+    if (data_len > 0) {
+        /* let the underlying libcoap decide how this data should be sent */
+        if (coap_add_data_large_request(
+                    session, pdu, data_len, data, NULL, NULL) == 0) {
+            charra_log_error(
+                    "[" LOG_NAME
+                    "] Cannot add (large) data option list to request");
+            goto error;
+        }
+    }
 
-	return pdu;
+    return pdu;
 
 error:
-	/* cleanup */
-	if (pdu != NULL) {
-		coap_delete_pdu(pdu);
-		// coap_free_type(COAP_PDU, pdu);
-	}
+    /* cleanup */
+    if (pdu != NULL) {
+        coap_delete_pdu(pdu);
+        // coap_free_type(COAP_PDU, pdu);
+    }
 
-	return NULL;
+    return NULL;
 }
 
 void charra_coap_add_resource(struct coap_context_t* coap_context,
-	const coap_request_t method, const char* resource_name,
-	const coap_method_handler_t handler) {
-	charra_log_info("[" LOG_NAME "] Adding CoAP %s resource '%s'.",
-		charra_coap_method_to_str(method), resource_name);
+        const coap_request_t method, const char* resource_name,
+        const coap_method_handler_t handler) {
+    charra_log_info("[" LOG_NAME "] Adding CoAP %s resource '%s'.",
+            charra_coap_method_to_str(method), resource_name);
 
-	coap_str_const_t* resource_uri = coap_new_str_const(
-		(uint8_t const*)resource_name, strlen(resource_name));
-	coap_resource_t* resource =
-		coap_resource_init(resource_uri, COAP_RESOURCE_FLAGS_RELEASE_URI);
-	coap_register_handler(resource, method, handler);
-	coap_add_resource(coap_context, resource);
+    coap_str_const_t* resource_uri = coap_new_str_const(
+            (uint8_t const*)resource_name, strlen(resource_name));
+    coap_resource_t* resource =
+            coap_resource_init(resource_uri, COAP_RESOURCE_FLAGS_RELEASE_URI);
+    coap_register_handler(resource, method, handler);
+    coap_add_resource(coap_context, resource);
 }
 
 CHARRA_RC charra_coap_setup_dtls_pki_for_rpk(coap_dtls_pki_t* dtls_pki,
-	char* private_key_path, char* public_key_path, char* peer_public_key_path,
-	bool verify_peer_public_key) {
-	// read public key file
-	char* public_key_file = NULL;
-	size_t public_key_file_length = 0;
-	CHARRA_RC rc = charra_io_read_file(
-		public_key_path, &public_key_file, &public_key_file_length);
-	if (rc != CHARRA_RC_SUCCESS) {
-		charra_log_error(
-			"[" LOG_NAME "] Cannot read file at path '%s'", public_key_path);
-		return rc;
-	}
+        char* private_key_path, char* public_key_path,
+        char* peer_public_key_path, bool verify_peer_public_key) {
+    // read public key file
+    char* public_key_file = NULL;
+    size_t public_key_file_length = 0;
+    CHARRA_RC rc = charra_io_read_file(
+            public_key_path, &public_key_file, &public_key_file_length);
+    if (rc != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Cannot read file at path '%s'",
+                public_key_path);
+        return rc;
+    }
 
-	// read private key file
-	char* private_key_file = NULL;
-	size_t private_key_file_length = 0;
-	rc = charra_io_read_file(
-		private_key_path, &private_key_file, &private_key_file_length);
-	if (rc != CHARRA_RC_SUCCESS) {
-		charra_log_error(
-			"[" LOG_NAME "] Cannot read file at path '%s'", private_key_path);
-		return rc;
-	}
+    // read private key file
+    char* private_key_file = NULL;
+    size_t private_key_file_length = 0;
+    rc = charra_io_read_file(
+            private_key_path, &private_key_file, &private_key_file_length);
+    if (rc != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Cannot read file at path '%s'",
+                private_key_path);
+        return rc;
+    }
 
-	// DTLS setup for PKI / RPK (raw public keys)
-	dtls_pki->version = COAP_DTLS_PKI_SETUP_VERSION;
-	dtls_pki->verify_peer_cert = 1;	 // not documented to be ignored when RPK is
-									 // used, but seems like it is?
-	dtls_pki->check_common_ca = 0;	 // ignored when RPK is used
-	dtls_pki->allow_self_signed = 0; // ignored when RPK is used
-	dtls_pki->allow_expired_certs = 0;	   // ignored when RPK is used
-	dtls_pki->cert_chain_validation = 0;   // ignored when RPK is used
-	dtls_pki->cert_chain_verify_depth = 0; // ignored when RPK is used
-	dtls_pki->check_cert_revocation = 0;   // ignored when RPK is used
-	dtls_pki->allow_no_crl = 0;			   // ignored when RPK is used
-	dtls_pki->allow_expired_crl = 0;	   // ignored when RPK is used
-	dtls_pki->allow_bad_md_hash = 0;	   // ignored when RPK is used
-	dtls_pki->allow_short_rsa_length = 0;  // ignored when RPK is used
-	dtls_pki->is_rpk_not_cert = 1;		   // use RPK instead of PKI
-	dtls_pki->validate_cn_call_back =
-		verify_peer_public_key ? verify_rpk_peer_callback : NULL;
-	dtls_pki->cn_call_back_arg = (void*)peer_public_key_path;
-	dtls_pki->validate_sni_call_back = NULL;
-	dtls_pki->sni_call_back_arg = NULL;
-	dtls_pki->additional_tls_setup_call_back = NULL;
-	dtls_pki->client_sni = NULL;
-	dtls_pki->pki_key.key_type = COAP_PKI_KEY_ASN1;
-	dtls_pki->pki_key.key.asn1.ca_cert = NULL;
-	dtls_pki->pki_key.key.asn1.ca_cert_len = 0;
-	dtls_pki->pki_key.key.asn1.public_cert = (uint8_t*)public_key_file;
-	dtls_pki->pki_key.key.asn1.public_cert_len = public_key_file_length;
-	dtls_pki->pki_key.key.asn1.private_key = (uint8_t*)private_key_file;
-	dtls_pki->pki_key.key.asn1.private_key_len = private_key_file_length;
-	dtls_pki->pki_key.key.asn1.private_key_type = COAP_ASN1_PKEY_EC;
+    // DTLS setup for PKI / RPK (raw public keys)
+    dtls_pki->version = COAP_DTLS_PKI_SETUP_VERSION;
+    dtls_pki->verify_peer_cert = 1;  // not documented to be ignored when RPK is
+                                     // used, but seems like it is?
+    dtls_pki->check_common_ca = 0;   // ignored when RPK is used
+    dtls_pki->allow_self_signed = 0;        // ignored when RPK is used
+    dtls_pki->allow_expired_certs = 0;      // ignored when RPK is used
+    dtls_pki->cert_chain_validation = 0;    // ignored when RPK is used
+    dtls_pki->cert_chain_verify_depth = 0;  // ignored when RPK is used
+    dtls_pki->check_cert_revocation = 0;    // ignored when RPK is used
+    dtls_pki->allow_no_crl = 0;             // ignored when RPK is used
+    dtls_pki->allow_expired_crl = 0;        // ignored when RPK is used
+    dtls_pki->allow_bad_md_hash = 0;        // ignored when RPK is used
+    dtls_pki->allow_short_rsa_length = 0;   // ignored when RPK is used
+    dtls_pki->is_rpk_not_cert = 1;          // use RPK instead of PKI
+    dtls_pki->validate_cn_call_back =
+            verify_peer_public_key ? verify_rpk_peer_callback : NULL;
+    dtls_pki->cn_call_back_arg = (void*)peer_public_key_path;
+    dtls_pki->validate_sni_call_back = NULL;
+    dtls_pki->sni_call_back_arg = NULL;
+    dtls_pki->additional_tls_setup_call_back = NULL;
+    dtls_pki->client_sni = NULL;
+    dtls_pki->pki_key.key_type = COAP_PKI_KEY_ASN1;
+    dtls_pki->pki_key.key.asn1.ca_cert = NULL;
+    dtls_pki->pki_key.key.asn1.ca_cert_len = 0;
+    dtls_pki->pki_key.key.asn1.public_cert = (uint8_t*)public_key_file;
+    dtls_pki->pki_key.key.asn1.public_cert_len = public_key_file_length;
+    dtls_pki->pki_key.key.asn1.private_key = (uint8_t*)private_key_file;
+    dtls_pki->pki_key.key.asn1.private_key_len = private_key_file_length;
+    dtls_pki->pki_key.key.asn1.private_key_type = COAP_ASN1_PKEY_EC;
 
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 }
 
 int charra_coap_log_level_from_str(
-	const char* log_level_str, coap_log_t* log_level) {
-	if (log_level_str != NULL) {
-		int array_size = sizeof(coap_level_names) / sizeof(coap_level_names[0]);
-		for (int i = 0; i < array_size; i++) {
-			const char* name = coap_level_names[i];
-			if (name == NULL) {
-				continue;
-			}
-			if (strcmp(name, log_level_str) == 0) {
-				*log_level = i;
-				return 0;
-			}
-		}
-		return -1;
-	}
+        const char* log_level_str, coap_log_t* log_level) {
+    if (log_level_str != NULL) {
+        int array_size = sizeof(coap_level_names) / sizeof(coap_level_names[0]);
+        for (int i = 0; i < array_size; i++) {
+            const char* name = coap_level_names[i];
+            if (name == NULL) {
+                continue;
+            }
+            if (strcmp(name, log_level_str) == 0) {
+                *log_level = i;
+                return 0;
+            }
+        }
+        return -1;
+    }
 
-	return -1;
+    return -1;
 }
 
 const char* charra_coap_method_to_str(const coap_request_t method) {
-	switch (method) {
-	case COAP_REQUEST_GET:
-		return "GET";
-	case COAP_REQUEST_POST:
-		return "POST";
-	case COAP_REQUEST_PUT:
-		return "PUT";
-	case COAP_REQUEST_DELETE:
-		return "DELETE";
-	case COAP_REQUEST_FETCH:
-		return "FETCH";
-	case COAP_REQUEST_PATCH:
-		return "PATCH";
-	case COAP_REQUEST_IPATCH:
-		return "IPATCH";
-	default:
-		return "UNKNOWN";
-	}
+    switch (method) {
+    case COAP_REQUEST_GET:
+        return "GET";
+    case COAP_REQUEST_POST:
+        return "POST";
+    case COAP_REQUEST_PUT:
+        return "PUT";
+    case COAP_REQUEST_DELETE:
+        return "DELETE";
+    case COAP_REQUEST_FETCH:
+        return "FETCH";
+    case COAP_REQUEST_PATCH:
+        return "PATCH";
+    case COAP_REQUEST_IPATCH:
+        return "IPATCH";
+    default:
+        return "UNKNOWN";
+    }
 }
 
 /**
@@ -321,40 +323,41 @@ const char* charra_coap_method_to_str(const coap_request_t method) {
  * @return 1 if accepted, else 0 if to be rejected
  */
 static int verify_rpk_peer_callback(const char* cn,
-	const uint8_t* asn1_public_cert, size_t asn1_length,
-	coap_session_t* session CHARRA_UNUSED, unsigned depth CHARRA_UNUSED,
-	int validated, void* arg) {
-	charra_log_info("[" LOG_NAME "] Checking peers public key for equivalence "
-					"against peers' known public key.");
-	if (strcmp("RPK", cn) == 0 && validated == 1) {
-		char* reference = NULL;
-		size_t reference_length = 0;
-		CHARRA_RC rc =
-			charra_io_read_file((char*)arg, &reference, &reference_length);
-		if (rc == CHARRA_RC_SUCCESS) {
-			if (reference_length == asn1_length) {
-				if (memcmp(reference, asn1_public_cert, reference_length) ==
-					0) {
-					return 1;
-				}
-			}
-			charra_log_error("[" LOG_NAME
-							 "] DTLS-RPK: The public key of the peer could not "
-							 "be verified with the reference key at path '%s'.",
-				(char*)arg);
-			charra_print_hex(CHARRA_LOG_DEBUG, reference_length, (uint8_t*) reference,
-				"Reference public key of peer: ", "\n", false);
-			charra_print_hex(CHARRA_LOG_DEBUG, asn1_length, asn1_public_cert,
-				"Actual public key of peer: ", "\n", false);
-			return 0;
-		}
-		charra_log_error("[" LOG_NAME "] DTLS-RPK: The reference key of the "
-						 "peer at path '%s' could not be opened.",
-			(char*)arg);
-		return 0;
-	}
-	charra_log_error(
-		"[" LOG_NAME
-		"] DTLS-RPK: Unexpected error while verifying peers' public key");
-	return 0;
+        const uint8_t* asn1_public_cert, size_t asn1_length,
+        coap_session_t* session CHARRA_UNUSED, unsigned depth CHARRA_UNUSED,
+        int validated, void* arg) {
+    charra_log_info("[" LOG_NAME "] Checking peers public key for equivalence "
+                    "against peers' known public key.");
+    if (strcmp("RPK", cn) == 0 && validated == 1) {
+        char* reference = NULL;
+        size_t reference_length = 0;
+        CHARRA_RC rc =
+                charra_io_read_file((char*)arg, &reference, &reference_length);
+        if (rc == CHARRA_RC_SUCCESS) {
+            if (reference_length == asn1_length) {
+                if (memcmp(reference, asn1_public_cert, reference_length) ==
+                        0) {
+                    return 1;
+                }
+            }
+            charra_log_error("[" LOG_NAME
+                             "] DTLS-RPK: The public key of the peer could not "
+                             "be verified with the reference key at path '%s'.",
+                    (char*)arg);
+            charra_print_hex(CHARRA_LOG_DEBUG, reference_length,
+                    (uint8_t*)reference, "Reference public key of peer: ", "\n",
+                    false);
+            charra_print_hex(CHARRA_LOG_DEBUG, asn1_length, asn1_public_cert,
+                    "Actual public key of peer: ", "\n", false);
+            return 0;
+        }
+        charra_log_error("[" LOG_NAME "] DTLS-RPK: The reference key of the "
+                         "peer at path '%s' could not be opened.",
+                (char*)arg);
+        return 0;
+    }
+    charra_log_error(
+            "[" LOG_NAME
+            "] DTLS-RPK: Unexpected error while verifying peers' public key");
+    return 0;
 }

--- a/src/util/coap_util.h
+++ b/src/util/coap_util.h
@@ -32,17 +32,17 @@
  *
  */
 typedef struct coap_token_t {
-	/**
-	 * @brief (Real) length of the token (max. 8).
-	 *
-	 */
-	size_t length;
+    /**
+     * @brief (Real) length of the token (max. 8).
+     *
+     */
+    size_t length;
 
-	/**
-	 * @brief The token (max. 8 bytes)
-	 *
-	 */
-	uint8_t data[8];
+    /**
+     * @brief The token (max. 8 bytes)
+     *
+     */
+    uint8_t data[8];
 } coap_token_t;
 
 /**
@@ -87,8 +87,8 @@ coap_context_t* charra_coap_new_context(const bool enable_coap_block_mode);
  * @return NULL if an error occurred.
  */
 coap_endpoint_t* charra_coap_new_endpoint(coap_context_t* coap_context,
-	const char* listen_address, const uint16_t port,
-	const coap_proto_t coap_protocol);
+        const char* listen_address, const uint16_t port,
+        const coap_proto_t coap_protocol);
 
 /**
  * @brief Creates a CoAP client session.
@@ -101,8 +101,8 @@ coap_endpoint_t* charra_coap_new_endpoint(coap_context_t* coap_context,
  * @return NULL if an error occurred.
  */
 coap_session_t* charra_coap_new_client_session(coap_context_t* coap_context,
-	const char* dest_address, const uint16_t port,
-	const coap_proto_t coap_protocol);
+        const char* dest_address, const uint16_t port,
+        const coap_proto_t coap_protocol);
 
 /**
  * @brief Creates a CoAP client session with PSK.
@@ -118,9 +118,9 @@ coap_session_t* charra_coap_new_client_session(coap_context_t* coap_context,
  * @return NULL if an error occurred.
  */
 coap_session_t* charra_coap_new_client_session_psk(coap_context_t* coap_context,
-	const char* dest_address, const uint16_t port,
-	const coap_proto_t coap_protocol, const char* identity, const uint8_t* key,
-	unsigned key_length);
+        const char* dest_address, const uint16_t port,
+        const coap_proto_t coap_protocol, const char* identity,
+        const uint8_t* key, unsigned key_length);
 
 /**
  * @brief Creates a CoAP client session with PKI.
@@ -135,8 +135,8 @@ coap_session_t* charra_coap_new_client_session_psk(coap_context_t* coap_context,
  * @return NULL if an error occurred.
  */
 coap_session_t* charra_coap_new_client_session_pki(coap_context_t* coap_context,
-	const char* dest_address, const uint16_t port,
-	const coap_proto_t coap_protocol, coap_dtls_pki_t* dtls_pki);
+        const char* dest_address, const uint16_t port,
+        const coap_proto_t coap_protocol, coap_dtls_pki_t* dtls_pki);
 
 /**
  * @brief Creates a new CoAP request with large data, using CoAP block-wise
@@ -154,8 +154,8 @@ coap_session_t* charra_coap_new_client_session_pki(coap_context_t* coap_context,
  * @return NULL in case of an error.
  */
 coap_pdu_t* charra_coap_new_request(coap_session_t* session,
-	coap_message_t msg_type, coap_request_t method, coap_optlist_t** options,
-	const uint8_t* data, const size_t data_len);
+        coap_message_t msg_type, coap_request_t method,
+        coap_optlist_t** options, const uint8_t* data, const size_t data_len);
 
 /**
  * @brief Adds a CoAP resource.
@@ -166,8 +166,8 @@ coap_pdu_t* charra_coap_new_request(coap_session_t* session,
  * @param handler the method handler function.
  */
 void charra_coap_add_resource(struct coap_context_t* coap_context,
-	const coap_request_t method, const char* resource_name,
-	const coap_method_handler_t handler);
+        const coap_request_t method, const char* resource_name,
+        const coap_method_handler_t handler);
 
 /**
  * @brief: Setup the dtls_pki structure for DTLS-RPK.
@@ -180,8 +180,8 @@ void charra_coap_add_resource(struct coap_context_t* coap_context,
  * validate the peers' public key, false otherwise
  */
 CHARRA_RC charra_coap_setup_dtls_pki_for_rpk(coap_dtls_pki_t* dtls_pki,
-	char* private_key_path, char* public_key_path, char* peer_public_key_path,
-	bool verify_peer_public_key);
+        char* private_key_path, char* public_key_path,
+        char* peer_public_key_path, bool verify_peer_public_key);
 
 /**
  * @brief Parses the libcoap log level from string and writes the result into
@@ -193,7 +193,7 @@ CHARRA_RC charra_coap_setup_dtls_pki_for_rpk(coap_dtls_pki_t* dtls_pki,
  * @return 0 on success, -1 on error.
  */
 int charra_coap_log_level_from_str(
-	const char* log_level_str, coap_log_t* log_level);
+        const char* log_level_str, coap_log_t* log_level);
 
 /**
  * @brief Returns the string representation of a CoAP request method.

--- a/src/util/crypto_util.c
+++ b/src/util/crypto_util.c
@@ -34,317 +34,318 @@
 /* hashing functions */
 
 CHARRA_RC hash_sha1(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA1_DIGEST_SIZE]) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
+        uint8_t digest[TPM2_SHA1_DIGEST_SIZE]) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
 
-	/* init */
-	mbedtls_sha1_context ctx = {0};
-	mbedtls_sha1_init(&ctx);
+    /* init */
+    mbedtls_sha1_context ctx = {0};
+    mbedtls_sha1_init(&ctx);
 
-	/* hash */
-	if ((mbedtls_sha1_starts(&ctx)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* hash */
+    if ((mbedtls_sha1_starts(&ctx)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_sha1_update(&ctx, data, data_len)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha1_update(&ctx, data, data_len)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_sha1_finish(&ctx, digest)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha1_finish(&ctx, digest)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	/* free */
-	mbedtls_sha1_free(&ctx);
+    /* free */
+    mbedtls_sha1_free(&ctx);
 
-	return r;
+    return r;
 }
 
 CHARRA_RC hash_sha256(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA256_DIGEST_SIZE]) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
+        uint8_t digest[TPM2_SHA256_DIGEST_SIZE]) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
 
-	/* init */
-	mbedtls_sha256_context ctx = {0};
-	mbedtls_sha256_init(&ctx);
+    /* init */
+    mbedtls_sha256_context ctx = {0};
+    mbedtls_sha256_init(&ctx);
 
-	/* hash */
-	if ((mbedtls_sha256_starts(&ctx, 0)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* hash */
+    if ((mbedtls_sha256_starts(&ctx, 0)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_sha256_update(&ctx, data, data_len)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha256_update(&ctx, data, data_len)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_sha256_finish(&ctx, digest)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha256_finish(&ctx, digest)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	/* free */
-	mbedtls_sha256_free(&ctx);
+    /* free */
+    mbedtls_sha256_free(&ctx);
 
-	return r;
+    return r;
 }
 
 CHARRA_RC hash_sha256_array(uint8_t* data[TPM2_SHA256_DIGEST_SIZE],
-	const size_t data_len, uint8_t digest[TPM2_SHA256_DIGEST_SIZE]) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
+        const size_t data_len, uint8_t digest[TPM2_SHA256_DIGEST_SIZE]) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
 
-	/* init */
-	mbedtls_sha256_context ctx = {0};
-	mbedtls_sha256_init(&ctx);
+    /* init */
+    mbedtls_sha256_context ctx = {0};
+    mbedtls_sha256_init(&ctx);
 
-	/* hash */
-	if ((mbedtls_sha256_starts(&ctx, 0)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* hash */
+    if ((mbedtls_sha256_starts(&ctx, 0)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	for (size_t i = 0; i < data_len; ++i) {
-		if ((mbedtls_sha256_update(&ctx, data[i], TPM2_SHA256_DIGEST_SIZE)) !=
-			0) {
-			r = CHARRA_RC_CRYPTO_ERROR;
-			goto error;
-		}
-	}
+    for (size_t i = 0; i < data_len; ++i) {
+        if ((mbedtls_sha256_update(&ctx, data[i], TPM2_SHA256_DIGEST_SIZE)) !=
+                0) {
+            r = CHARRA_RC_CRYPTO_ERROR;
+            goto error;
+        }
+    }
 
-	if ((mbedtls_sha256_finish(&ctx, digest)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha256_finish(&ctx, digest)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	/* free */
-	mbedtls_sha256_free(&ctx);
+    /* free */
+    mbedtls_sha256_free(&ctx);
 
-	return r;
+    return r;
 }
 
 CHARRA_RC hash_sha512(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA512_DIGEST_SIZE]) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
+        uint8_t digest[TPM2_SHA512_DIGEST_SIZE]) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
 
-	/* init */
-	mbedtls_sha512_context ctx = {0};
-	mbedtls_sha512_init(&ctx);
+    /* init */
+    mbedtls_sha512_context ctx = {0};
+    mbedtls_sha512_init(&ctx);
 
-	/* hash */
-	if ((mbedtls_sha512_starts(&ctx, 0)) != 0) { // 0 = SHA512
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* hash */
+    if ((mbedtls_sha512_starts(&ctx, 0)) != 0) {  // 0 = SHA512
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_sha512_update(&ctx, data, data_len)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha512_update(&ctx, data, data_len)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_sha512_finish(&ctx, digest)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_sha512_finish(&ctx, digest)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	/* free */
-	mbedtls_sha512_free(&ctx);
+    /* free */
+    mbedtls_sha512_free(&ctx);
 
-	return r;
+    return r;
 }
 
 CHARRA_RC charra_crypto_hash(mbedtls_md_type_t hash_algo,
-	const uint8_t* const data, const size_t data_len,
-	uint8_t digest[MBEDTLS_MD_MAX_SIZE]) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
+        const uint8_t* const data, const size_t data_len,
+        uint8_t digest[MBEDTLS_MD_MAX_SIZE]) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
 
-	/* init and setup */
-	const mbedtls_md_info_t* hash_info = mbedtls_md_info_from_type(hash_algo);
-	mbedtls_md_context_t ctx = {0};
-	mbedtls_md_init(&ctx);
-	if ((mbedtls_md_setup(&ctx, hash_info, 0)) != 0) { // 0 = do not use HMAC
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* init and setup */
+    const mbedtls_md_info_t* hash_info = mbedtls_md_info_from_type(hash_algo);
+    mbedtls_md_context_t ctx = {0};
+    mbedtls_md_init(&ctx);
+    if ((mbedtls_md_setup(&ctx, hash_info, 0)) != 0) {  // 0 = do not use HMAC
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	/* hash */
-	if ((mbedtls_md_starts(&ctx)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* hash */
+    if ((mbedtls_md_starts(&ctx)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_md_update(&ctx, data, data_len)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_md_update(&ctx, data, data_len)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
-	if ((mbedtls_md_finish(&ctx, digest)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    if ((mbedtls_md_finish(&ctx, digest)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	/* free */
-	mbedtls_md_free(&ctx);
+    /* free */
+    mbedtls_md_free(&ctx);
 
-	return r;
+    return r;
 }
 
 CHARRA_RC charra_crypto_tpm_pub_key_to_mbedtls_pub_key(
-	const TPM2B_PUBLIC* tpm_rsa_pub_key,
-	mbedtls_rsa_context* mbedtls_rsa_pub_key) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
-	int mbedtls_r = 0;
+        const TPM2B_PUBLIC* tpm_rsa_pub_key,
+        mbedtls_rsa_context* mbedtls_rsa_pub_key) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
+    int mbedtls_r = 0;
 
-	/* construct a RSA public key from modulus and exponent */
-	mbedtls_mpi n = {0}; /* modulus */
-	mbedtls_mpi e = {0}; /* exponent */
+    /* construct a RSA public key from modulus and exponent */
+    mbedtls_mpi n = {0}; /* modulus */
+    mbedtls_mpi e = {0}; /* exponent */
 
-	/* init mbed TLS structures */
-	mbedtls_rsa_init(mbedtls_rsa_pub_key);
-	if (mbedtls_rsa_set_padding(
-			mbedtls_rsa_pub_key, MBEDTLS_RSA_PKCS_V21, MBEDTLS_MD_NONE) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		charra_log_error("mbedtls_rsa_set_padding");
-		goto error;
-	}
-	mbedtls_mpi_init(&n);
-	mbedtls_mpi_init(&e);
+    /* init mbed TLS structures */
+    mbedtls_rsa_init(mbedtls_rsa_pub_key);
+    if (mbedtls_rsa_set_padding(mbedtls_rsa_pub_key, MBEDTLS_RSA_PKCS_V21,
+                MBEDTLS_MD_NONE) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        charra_log_error("mbedtls_rsa_set_padding");
+        goto error;
+    }
+    mbedtls_mpi_init(&n);
+    mbedtls_mpi_init(&e);
 
-	/* set modulus */
-	if ((mbedtls_r = mbedtls_mpi_read_binary(&n,
-			 (const unsigned char*)
-				 tpm_rsa_pub_key->publicArea.unique.rsa.buffer,
-			 (size_t)tpm_rsa_pub_key->publicArea.unique.rsa.size)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		charra_log_error("mbedtls_mpi_read_binary");
-		goto error;
-	}
+    /* set modulus */
+    if ((mbedtls_r = mbedtls_mpi_read_binary(&n,
+                 (const unsigned char*)
+                         tpm_rsa_pub_key->publicArea.unique.rsa.buffer,
+                 (size_t)tpm_rsa_pub_key->publicArea.unique.rsa.size)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        charra_log_error("mbedtls_mpi_read_binary");
+        goto error;
+    }
 
-	{ /* set exponent from TPM public key (if 0 set it to 65537) */
-		uint32_t exp = 65537; /* set default exponent */
-		if (tpm_rsa_pub_key->publicArea.parameters.rsaDetail.exponent != 0) {
-			exp = tpm_rsa_pub_key->publicArea.parameters.rsaDetail.exponent;
-		}
+    { /* set exponent from TPM public key (if 0 set it to 65537) */
+        uint32_t exp = 65537; /* set default exponent */
+        if (tpm_rsa_pub_key->publicArea.parameters.rsaDetail.exponent != 0) {
+            exp = tpm_rsa_pub_key->publicArea.parameters.rsaDetail.exponent;
+        }
 
-		if ((mbedtls_r = mbedtls_mpi_lset(&e, (mbedtls_mpi_sint)exp)) != 0) {
-			r = CHARRA_RC_CRYPTO_ERROR;
-			charra_log_error("mbedtls_mpi_lset");
-			goto error;
-		}
-	}
+        if ((mbedtls_r = mbedtls_mpi_lset(&e, (mbedtls_mpi_sint)exp)) != 0) {
+            r = CHARRA_RC_CRYPTO_ERROR;
+            charra_log_error("mbedtls_mpi_lset");
+            goto error;
+        }
+    }
 
-	if ((mbedtls_r = mbedtls_rsa_import(
-			 mbedtls_rsa_pub_key, &n, NULL, NULL, NULL, &e)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		charra_log_error("mbedtls_rsa_import");
-		goto error;
-	}
+    if ((mbedtls_r = mbedtls_rsa_import(
+                 mbedtls_rsa_pub_key, &n, NULL, NULL, NULL, &e)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        charra_log_error("mbedtls_rsa_import");
+        goto error;
+    }
 
-	if ((mbedtls_r = mbedtls_rsa_complete(mbedtls_rsa_pub_key)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		charra_log_error("mbedtls_rsa_complete");
-		goto error;
-	}
+    if ((mbedtls_r = mbedtls_rsa_complete(mbedtls_rsa_pub_key)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        charra_log_error("mbedtls_rsa_complete");
+        goto error;
+    }
 
-	if ((mbedtls_r = mbedtls_rsa_check_pubkey(mbedtls_rsa_pub_key)) != 0) {
-		r = CHARRA_RC_CRYPTO_ERROR;
-		charra_log_error("mbedtls_rsa_check_pubkey");
-		goto error;
-	}
+    if ((mbedtls_r = mbedtls_rsa_check_pubkey(mbedtls_rsa_pub_key)) != 0) {
+        r = CHARRA_RC_CRYPTO_ERROR;
+        charra_log_error("mbedtls_rsa_check_pubkey");
+        goto error;
+    }
 
-	/* cleanup */
-	mbedtls_mpi_free(&n);
-	mbedtls_mpi_free(&e);
+    /* cleanup */
+    mbedtls_mpi_free(&n);
+    mbedtls_mpi_free(&e);
 
-	return CHARRA_RC_SUCCESS;
+    return CHARRA_RC_SUCCESS;
 
 error:
-	/* cleanup */
-	mbedtls_rsa_free(mbedtls_rsa_pub_key);
-	mbedtls_mpi_free(&n);
-	mbedtls_mpi_free(&e);
+    /* cleanup */
+    mbedtls_rsa_free(mbedtls_rsa_pub_key);
+    mbedtls_mpi_free(&n);
+    mbedtls_mpi_free(&e);
 
-	return r;
+    return r;
 }
 
 CHARRA_RC charra_crypto_rsa_verify_signature_hashed(
-	mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
-	const unsigned char* data_digest, const unsigned char* signature) {
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
-	int mbedtls_r = 0;
+        mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
+        const unsigned char* data_digest, const unsigned char* signature) {
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+    int mbedtls_r = 0;
 
-	/* get hash digest size */
-	const mbedtls_md_info_t* md_info = mbedtls_md_info_from_type(hash_algo);
-	if (md_info == NULL) {
-		charra_r = CHARRA_RC_CRYPTO_ERROR;
-		charra_log_error("mbedtls_md_info_from_type");
-		goto error;
-	}
-	uint8_t hash_digest_size = mbedtls_md_get_size(md_info);
+    /* get hash digest size */
+    const mbedtls_md_info_t* md_info = mbedtls_md_info_from_type(hash_algo);
+    if (md_info == NULL) {
+        charra_r = CHARRA_RC_CRYPTO_ERROR;
+        charra_log_error("mbedtls_md_info_from_type");
+        goto error;
+    }
+    uint8_t hash_digest_size = mbedtls_md_get_size(md_info);
 
-	/* verify signature */
-	if ((mbedtls_r = mbedtls_rsa_rsassa_pss_verify(mbedtls_rsa_pub_key,
-			 hash_algo, hash_digest_size, data_digest, signature)) != 0) {
-		charra_r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* verify signature */
+    if ((mbedtls_r = mbedtls_rsa_rsassa_pss_verify(mbedtls_rsa_pub_key,
+                 hash_algo, hash_digest_size, data_digest, signature)) != 0) {
+        charra_r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	return charra_r;
+    return charra_r;
 }
 
 CHARRA_RC charra_crypto_rsa_verify_signature(
-	mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
-	const unsigned char* data, size_t data_len,
-	const unsigned char* signature) {
-	CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
+        mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
+        const unsigned char* data, size_t data_len,
+        const unsigned char* signature) {
+    CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
 
-	/* hash data */
-	uint8_t data_digest[MBEDTLS_MD_MAX_SIZE] = {0};
-	if ((charra_r = charra_crypto_hash(
-			 hash_algo, data, data_len, data_digest)) != CHARRA_RC_SUCCESS) {
-		goto error;
-	}
+    /* hash data */
+    uint8_t data_digest[MBEDTLS_MD_MAX_SIZE] = {0};
+    if ((charra_r = charra_crypto_hash(hash_algo, data, data_len,
+                 data_digest)) != CHARRA_RC_SUCCESS) {
+        goto error;
+    }
 
-	/* verify signature */
-	if ((charra_r = charra_crypto_rsa_verify_signature_hashed(
-			 mbedtls_rsa_pub_key, hash_algo, data_digest, signature)) != 0) {
-		charra_r = CHARRA_RC_CRYPTO_ERROR;
-		goto error;
-	}
+    /* verify signature */
+    if ((charra_r = charra_crypto_rsa_verify_signature_hashed(
+                 mbedtls_rsa_pub_key, hash_algo, data_digest, signature)) !=
+            0) {
+        charra_r = CHARRA_RC_CRYPTO_ERROR;
+        goto error;
+    }
 
 error:
-	return charra_r;
+    return charra_r;
 }
 
 CHARRA_RC compute_and_check_PCR_digest(uint8_t** pcr_values,
-	uint32_t pcr_values_len, const TPMS_ATTEST* const attest_struct) {
-	uint8_t pcr_composite_digest[TPM2_SHA256_DIGEST_SIZE] = {0};
-	/* TODO use crypto-agile (generic) version
-	 * charra_compute_pcr_composite_digest_from_ptr_array(), once
-	 * implemented, instead of hash_sha256_array() (then maybe remove
-	 * hash_sha256_array() function) */
-	CHARRA_RC charra_r =
-		hash_sha256_array(pcr_values, pcr_values_len, pcr_composite_digest);
-	if (charra_r != CHARRA_RC_SUCCESS) {
-		return CHARRA_RC_ERROR;
-	}
-	bool matching = charra_verify_tpm2_quote_pcr_composite_digest(
-		attest_struct, pcr_composite_digest, TPM2_SHA256_DIGEST_SIZE);
-	charra_print_hex(CHARRA_LOG_DEBUG, sizeof(pcr_composite_digest),
-		pcr_composite_digest,
-		"                                              0x", "\n", false);
-	if (matching) {
-		return CHARRA_RC_SUCCESS;
-	} else {
-		return CHARRA_RC_NO_MATCH;
-	}
+        uint32_t pcr_values_len, const TPMS_ATTEST* const attest_struct) {
+    uint8_t pcr_composite_digest[TPM2_SHA256_DIGEST_SIZE] = {0};
+    /* TODO use crypto-agile (generic) version
+     * charra_compute_pcr_composite_digest_from_ptr_array(), once
+     * implemented, instead of hash_sha256_array() (then maybe remove
+     * hash_sha256_array() function) */
+    CHARRA_RC charra_r =
+            hash_sha256_array(pcr_values, pcr_values_len, pcr_composite_digest);
+    if (charra_r != CHARRA_RC_SUCCESS) {
+        return CHARRA_RC_ERROR;
+    }
+    bool matching = charra_verify_tpm2_quote_pcr_composite_digest(
+            attest_struct, pcr_composite_digest, TPM2_SHA256_DIGEST_SIZE);
+    charra_print_hex(CHARRA_LOG_DEBUG, sizeof(pcr_composite_digest),
+            pcr_composite_digest,
+            "                                              0x", "\n", false);
+    if (matching) {
+        return CHARRA_RC_SUCCESS;
+    } else {
+        return CHARRA_RC_NO_MATCH;
+    }
 }

--- a/src/util/crypto_util.h
+++ b/src/util/crypto_util.h
@@ -33,50 +33,51 @@
 /* hashing functions */
 
 CHARRA_RC hash_sha1(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA1_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA1_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha1_array(const size_t count, const uint8_t* const array,
-	uint8_t digest[TPM2_SHA1_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA1_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha256(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA256_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA256_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha256_array(uint8_t* data[TPM2_SHA256_DIGEST_SIZE],
-	const size_t data_len, uint8_t digest[TPM2_SHA256_DIGEST_SIZE]);
+        const size_t data_len, uint8_t digest[TPM2_SHA256_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha384(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA384_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA384_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha384_array(const size_t count, const uint8_t* const array,
-	uint8_t digest[TPM2_SHA384_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA384_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha512(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SHA512_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA512_DIGEST_SIZE]);
 
 CHARRA_RC hash_sha512_array(const size_t count, const uint8_t* const array,
-	uint8_t digest[TPM2_SHA512_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SHA512_DIGEST_SIZE]);
 
 CHARRA_RC hash_sm3_256(const size_t data_len, const uint8_t* const data,
-	uint8_t digest[TPM2_SM3_256_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SM3_256_DIGEST_SIZE]);
 
 CHARRA_RC hash_sm3_256_array(const size_t count, const uint8_t* const array,
-	uint8_t digest[TPM2_SM3_256_DIGEST_SIZE]);
+        uint8_t digest[TPM2_SM3_256_DIGEST_SIZE]);
 
 CHARRA_RC charra_crypto_hash(mbedtls_md_type_t hash_algo,
-	const uint8_t* const data, const size_t data_len,
-	uint8_t digest[MBEDTLS_MD_MAX_SIZE]);
+        const uint8_t* const data, const size_t data_len,
+        uint8_t digest[MBEDTLS_MD_MAX_SIZE]);
 
 CHARRA_RC charra_crypto_tpm_pub_key_to_mbedtls_pub_key(
-	const TPM2B_PUBLIC* tpm_rsa_pub_key,
-	mbedtls_rsa_context* mbedtls_rsa_pub_key);
+        const TPM2B_PUBLIC* tpm_rsa_pub_key,
+        mbedtls_rsa_context* mbedtls_rsa_pub_key);
 
 CHARRA_RC charra_crypto_rsa_verify_signature_hashed(
-	mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
-	const unsigned char* data_digest, const unsigned char* signature);
+        mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
+        const unsigned char* data_digest, const unsigned char* signature);
 
 CHARRA_RC charra_crypto_rsa_verify_signature(
-	mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
-	const unsigned char* data, size_t data_len, const unsigned char* signature);
+        mbedtls_rsa_context* mbedtls_rsa_pub_key, mbedtls_md_type_t hash_algo,
+        const unsigned char* data, size_t data_len,
+        const unsigned char* signature);
 
 /**
  * @brief Compute PCR composite digest from PCR values and check if it matches
@@ -89,6 +90,6 @@ CHARRA_RC charra_crypto_rsa_verify_signature(
  * on non-matching digests, CHARRA_RC_ERROR on error
  */
 CHARRA_RC compute_and_check_PCR_digest(uint8_t** pcr_values,
-	uint32_t pcr_value_len, const TPMS_ATTEST* const attest_struct);
+        uint32_t pcr_value_len, const TPMS_ATTEST* const attest_struct);
 
 #endif /* SITIMA_CRYPTO_H */

--- a/src/util/io_util.c
+++ b/src/util/io_util.c
@@ -30,165 +30,165 @@
 #include <unistd.h>
 
 void charra_print_hex(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* const prefix,
-	const char* const postfix, const bool upper_case) {
-	const char* const hex_case = upper_case ? "%02X" : "%02x";
+        const uint8_t* const buf, const char* const prefix,
+        const char* const postfix, const bool upper_case) {
+    const char* const hex_case = upper_case ? "%02X" : "%02x";
 
-	charra_log_log_raw(level, "%s", prefix);
-	/* print upper case */
-	for (size_t i = 0; i < buf_len; ++i) {
-		charra_log_log_raw(level, hex_case, buf[i]);
-	}
-	charra_log_log_raw(level, "%s", postfix);
+    charra_log_log_raw(level, "%s", prefix);
+    /* print upper case */
+    for (size_t i = 0; i < buf_len; ++i) {
+        charra_log_log_raw(level, hex_case, buf[i]);
+    }
+    charra_log_log_raw(level, "%s", postfix);
 }
 
 void charra_print_str(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* const prefix,
-	const char* const postfix) {
+        const uint8_t* const buf, const char* const prefix,
+        const char* const postfix) {
 
-	charra_log_log_raw(level, "%s", prefix);
-	/* print upper case */
-	for (size_t i = 0; i < buf_len; ++i) {
-		charra_log_log_raw(level, "%c", buf[i]);
-	}
-	charra_log_log_raw(level, "%s", postfix);
+    charra_log_log_raw(level, "%s", prefix);
+    /* print upper case */
+    for (size_t i = 0; i < buf_len; ++i) {
+        charra_log_log_raw(level, "%c", buf[i]);
+    }
+    charra_log_log_raw(level, "%s", postfix);
 }
 
 void charra_print_pcr_content(const charra_log_t level,
-	const uint8_t* const pcr_selection, const uint32_t pcr_selection_len,
-	const uint8_t** const pcrs) {
-	for (uint32_t i = 0; i < pcr_selection_len; i++) {
-		charra_log_log_raw(level, "%02d: 0x", pcr_selection[i]);
-		for (uint32_t j = 0; j < TPM2_SHA256_DIGEST_SIZE; j++) {
-			charra_print_hex(level, 1, &pcrs[i][j], "", "", true);
-		}
-		charra_log_log_raw(level, "\n");
-	}
+        const uint8_t* const pcr_selection, const uint32_t pcr_selection_len,
+        const uint8_t** const pcrs) {
+    for (uint32_t i = 0; i < pcr_selection_len; i++) {
+        charra_log_log_raw(level, "%02d: 0x", pcr_selection[i]);
+        for (uint32_t j = 0; j < TPM2_SHA256_DIGEST_SIZE; j++) {
+            charra_print_hex(level, 1, &pcrs[i][j], "", "", true);
+        }
+        charra_log_log_raw(level, "\n");
+    }
 }
 
 CHARRA_RC charra_io_file_exists(const char* const filename) {
-	if (access(filename, F_OK) == 0) {
-		return CHARRA_RC_SUCCESS;
-	} else {
-		return CHARRA_RC_ERROR;
-	}
+    if (access(filename, F_OK) == 0) {
+        return CHARRA_RC_SUCCESS;
+    } else {
+        return CHARRA_RC_ERROR;
+    }
 }
 
 CHARRA_RC charra_io_read_file(const char* filename, char** const file_content,
-	size_t* const file_content_len) {
-	CHARRA_RC r = CHARRA_RC_SUCCESS;
-	FILE* fp = NULL;
+        size_t* const file_content_len) {
+    CHARRA_RC r = CHARRA_RC_SUCCESS;
+    FILE* fp = NULL;
 
-	/* open file */
-	if ((fp = fopen(filename, "r")) == NULL) {
-		charra_log_error("Cannot open file '%s'.", filename);
-		r = CHARRA_RC_ERROR;
-		goto error;
-	}
+    /* open file */
+    if ((fp = fopen(filename, "r")) == NULL) {
+        charra_log_error("Cannot open file '%s'.", filename);
+        r = CHARRA_RC_ERROR;
+        goto error;
+    }
 
-	/* get file size */
-	ssize_t file_size = -1;
-	{
-		/* go to end of file */
-		if (fseek(fp, 0L, SEEK_END) != 0) {
-			r = CHARRA_RC_ERROR;
-			goto error;
-		}
+    /* get file size */
+    ssize_t file_size = -1;
+    {
+        /* go to end of file */
+        if (fseek(fp, 0L, SEEK_END) != 0) {
+            r = CHARRA_RC_ERROR;
+            goto error;
+        }
 
-		/* get position (i.e., the file size) */
-		if ((file_size = ftell(fp)) == -1) {
-			r = CHARRA_RC_ERROR;
-			goto error;
-		}
+        /* get position (i.e., the file size) */
+        if ((file_size = ftell(fp)) == -1) {
+            r = CHARRA_RC_ERROR;
+            goto error;
+        }
 
-		/* go back to beginning of file */
-		if (fseek(fp, 0L, SEEK_SET) != 0) {
-			r = CHARRA_RC_ERROR;
-			goto error;
-		}
-	}
+        /* go back to beginning of file */
+        if (fseek(fp, 0L, SEEK_SET) != 0) {
+            r = CHARRA_RC_ERROR;
+            goto error;
+        }
+    }
 
-	/* allocate memory */
-	char* file_buffer = NULL;
-	if ((file_buffer = malloc(file_size * sizeof(*file_buffer))) == NULL) {
-		r = CHARRA_RC_ERROR;
-		goto error;
-	}
+    /* allocate memory */
+    char* file_buffer = NULL;
+    if ((file_buffer = malloc(file_size * sizeof(*file_buffer))) == NULL) {
+        r = CHARRA_RC_ERROR;
+        goto error;
+    }
 
-	size_t read_size = fread(file_buffer, sizeof(*file_buffer), file_size, fp);
-	if (read_size < (size_t)file_size) {
-		charra_log_error(
-			"Error while reading file '%s', expected size %zu, got size %zu.",
-			filename, file_size, read_size);
-		charra_free_if_not_null(file_buffer);
-		r = CHARRA_RC_ERROR;
-		goto error;
-	}
+    size_t read_size = fread(file_buffer, sizeof(*file_buffer), file_size, fp);
+    if (read_size < (size_t)file_size) {
+        charra_log_error("Error while reading file '%s', expected size %zu, "
+                         "got size %zu.",
+                filename, file_size, read_size);
+        charra_free_if_not_null(file_buffer);
+        r = CHARRA_RC_ERROR;
+        goto error;
+    }
 
-	/* set output arguments */
-	*file_content = file_buffer;
-	*file_content_len = read_size;
+    /* set output arguments */
+    *file_content = file_buffer;
+    *file_content_len = read_size;
 
 error:
 
-	/* close file */
-	if (fp != NULL) {
-		if (fclose(fp) != 0) {
-			charra_log_error("Error closing file '%s'.", filename);
-			charra_free_if_not_null(file_buffer);
-			return CHARRA_RC_ERROR;
-		}
-	}
+    /* close file */
+    if (fp != NULL) {
+        if (fclose(fp) != 0) {
+            charra_log_error("Error closing file '%s'.", filename);
+            charra_free_if_not_null(file_buffer);
+            return CHARRA_RC_ERROR;
+        }
+    }
 
-	return r;
+    return r;
 }
 
 void charra_io_free_file_buffer(char** const file_content) {
-	charra_free_if_not_null(*file_content);
+    charra_free_if_not_null(*file_content);
 }
 
 CHARRA_RC charra_io_read_continuous_binary_file(const char* const filename,
-	uint8_t** const file_content, size_t* const file_content_len) {
-	/* the size of the event log chunks which get read at once */
+        uint8_t** const file_content, size_t* const file_content_len) {
+    /* the size of the event log chunks which get read at once */
 #define IMA_EVENT_LOG_STEP_SIZE 1024
-	/*
-	 * Use logarithmic growth for the cvector. Otherwise it would grow on
-	 * every call to cvector_push_back().
-	 */
+    /*
+     * Use logarithmic growth for the cvector. Otherwise it would grow on
+     * every call to cvector_push_back().
+     */
 #define CVECTOR_LOGARITHMIC_GROWTH
 
-	cvector_vector_type(uint8_t) file_content_cvector = NULL;
-	FILE* fp = NULL;
-	if ((fp = fopen(filename, "rb")) == NULL) {
-		charra_log_error("Cannot open file '%s'.", filename);
-		return CHARRA_RC_ERROR;
-	}
-	uint8_t processing_array[IMA_EVENT_LOG_STEP_SIZE] = {0};
-	size_t read_size = 0;
-	do {
-		read_size = fread(processing_array, sizeof(*processing_array),
-			IMA_EVENT_LOG_STEP_SIZE, fp);
-		for (size_t i = 0; i < read_size; ++i) {
-			cvector_push_back(file_content_cvector, processing_array[i]);
-		}
-	} while (read_size == IMA_EVENT_LOG_STEP_SIZE);
+    cvector_vector_type(uint8_t) file_content_cvector = NULL;
+    FILE* fp = NULL;
+    if ((fp = fopen(filename, "rb")) == NULL) {
+        charra_log_error("Cannot open file '%s'.", filename);
+        return CHARRA_RC_ERROR;
+    }
+    uint8_t processing_array[IMA_EVENT_LOG_STEP_SIZE] = {0};
+    size_t read_size = 0;
+    do {
+        read_size = fread(processing_array, sizeof(*processing_array),
+                IMA_EVENT_LOG_STEP_SIZE, fp);
+        for (size_t i = 0; i < read_size; ++i) {
+            cvector_push_back(file_content_cvector, processing_array[i]);
+        }
+    } while (read_size == IMA_EVENT_LOG_STEP_SIZE);
 
-	/* flush and close file */
-	if (fflush(fp) != 0) {
-		charra_log_error("Error flushing file '%s'.", filename);
-		charra_free_if_not_null_ex(file_content_cvector, cvector_free);
-		return CHARRA_RC_ERROR;
-	}
-	if (fclose(fp) != 0) {
-		charra_log_error("Error closing file '%s'.", filename);
-		charra_free_if_not_null_ex(file_content_cvector, cvector_free);
-		return CHARRA_RC_ERROR;
-	}
-	*file_content_len = cvector_size(file_content_cvector);
-	*file_content = file_content_cvector;
-	return CHARRA_RC_SUCCESS;
+    /* flush and close file */
+    if (fflush(fp) != 0) {
+        charra_log_error("Error flushing file '%s'.", filename);
+        charra_free_if_not_null_ex(file_content_cvector, cvector_free);
+        return CHARRA_RC_ERROR;
+    }
+    if (fclose(fp) != 0) {
+        charra_log_error("Error closing file '%s'.", filename);
+        charra_free_if_not_null_ex(file_content_cvector, cvector_free);
+        return CHARRA_RC_ERROR;
+    }
+    *file_content_len = cvector_size(file_content_cvector);
+    *file_content = file_content_cvector;
+    return CHARRA_RC_SUCCESS;
 }
 
 void charra_io_free_continuous_file_buffer(uint8_t** const file_content) {
-	charra_free_if_not_null_ex(*file_content, cvector_free);
+    charra_free_if_not_null_ex(*file_content, cvector_free);
 }

--- a/src/util/io_util.h
+++ b/src/util/io_util.h
@@ -31,10 +31,10 @@
 
 #define CHARRA_BYTE_TO_BINARY_PATTERN "%c%c%c%c%c%c%c%c"
 #define CHARRA_BYTE_TO_BINARY(byte)                                            \
-	(byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'),                      \
-		(byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'),                  \
-		(byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'),                  \
-		(byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0')
+    (byte & 0x80 ? '1' : '0'), (byte & 0x40 ? '1' : '0'),                      \
+            (byte & 0x20 ? '1' : '0'), (byte & 0x10 ? '1' : '0'),              \
+            (byte & 0x08 ? '1' : '0'), (byte & 0x04 ? '1' : '0'),              \
+            (byte & 0x02 ? '1' : '0'), (byte & 0x01 ? '1' : '0')
 
 /**
  * @brief
@@ -48,8 +48,8 @@
  * in lowercase (e.g. "012..abcdef").
  */
 void charra_print_hex(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* const prefix,
-	const char* const postfix, const bool upper_case);
+        const uint8_t* const buf, const char* const prefix,
+        const char* const postfix, const bool upper_case);
 
 /**
  * @brief
@@ -62,8 +62,8 @@ void charra_print_hex(const charra_log_t level, const size_t buf_len,
  * @param postfix  A postfix to the output, e.g. "\n", or leave it empty ("").
  */
 void charra_print_str(const charra_log_t level, const size_t buf_len,
-	const uint8_t* const buf, const char* const prefix,
-	const char* const postfix);
+        const uint8_t* const buf, const char* const prefix,
+        const char* const postfix);
 
 /**
  * @brief Print PCR content of selected PCRs.
@@ -74,8 +74,8 @@ void charra_print_str(const charra_log_t level, const size_t buf_len,
  * @param pcrs the content of the PCRs
  */
 void charra_print_pcr_content(const charra_log_t level,
-	const uint8_t* const pcr_selection, const uint32_t pcr_selection_len,
-	const uint8_t** const pcrs);
+        const uint8_t* const pcr_selection, const uint32_t pcr_selection_len,
+        const uint8_t** const pcrs);
 
 /**
  * @brief Checks if file is existing.
@@ -96,7 +96,7 @@ CHARRA_RC charra_io_file_exists(const char* const filename);
  * @return CHARRA_RC CHARRA_RC_SUCCESS on success, otherwise CHARRA_RC_ERROR
  */
 CHARRA_RC charra_io_read_file(const char* filename, char** const file_content,
-	size_t* const file_content_len);
+        size_t* const file_content_len);
 
 /**
  * @brief free buffer holding the file content. Alternatively
@@ -119,7 +119,7 @@ void charra_io_free_file_buffer(char** const file_content);
  * @return CHARRA_RC CHARRA_RC_SUCCESS on success, otherwise CHARRA_RC_ERROR
  */
 CHARRA_RC charra_io_read_continuous_binary_file(const char* const filename,
-	uint8_t** const file_content, size_t* const file_content_len);
+        uint8_t** const file_content, size_t* const file_content_len);
 
 /**
  * @brief free cvector holding the file content.

--- a/src/util/parser_util.c
+++ b/src/util/parser_util.c
@@ -26,57 +26,58 @@
 #include <tss2/tss2_tpm2_types.h>
 
 CHARRA_RC parse_pcr_value(char* start, char* eol, uint8_t* pcr_value) {
-	// search for the start of the PCR hex value
-	char* hex_start;
-	for (hex_start = start;
-		 !(*(hex_start - 2) == '0' && *(hex_start - 1) == 'x'); hex_start++) {
-		if (hex_start >= eol) {
-			return CHARRA_RC_ERROR;
-		}
-	} // loop ends on first character after the '0x'
+    // search for the start of the PCR hex value
+    char* hex_start;
+    for (hex_start = start;
+            !(*(hex_start - 2) == '0' && *(hex_start - 1) == 'x');
+            hex_start++) {
+        if (hex_start >= eol) {
+            return CHARRA_RC_ERROR;
+        }
+    }  // loop ends on first character after the '0x'
 
-	// iterate over all bytes of the digest
-	for (uint32_t digest_index = 0; digest_index < TPM2_SHA256_DIGEST_SIZE;
-		 digest_index++) {
-		// hex_index is the byte in string representation at the
-		// current digest_index
-		char* hex_index = hex_start + (digest_index * 2);
-		if (hex_index + 1 >= eol) {
-			return CHARRA_RC_ERROR;
-		}
+    // iterate over all bytes of the digest
+    for (uint32_t digest_index = 0; digest_index < TPM2_SHA256_DIGEST_SIZE;
+            digest_index++) {
+        // hex_index is the byte in string representation at the
+        // current digest_index
+        char* hex_index = hex_start + (digest_index * 2);
+        if (hex_index + 1 >= eol) {
+            return CHARRA_RC_ERROR;
+        }
 
-		// convert byte in string representation to byte as uint8_t
-		char byte_as_string[3] = {0};
-		// copy substring into other string because otherwise strtoul
-		// would read more than one byte
-		memcpy(byte_as_string, hex_index, 2);
-		byte_as_string[2] = '\0';
-		errno = 0;
-		char* eol = NULL;
-		unsigned long int hex_value = strtoul(byte_as_string, &eol, 16);
-		if (eol == byte_as_string || errno != 0 || hex_value > 255) {
-			return CHARRA_RC_ERROR;
-		}
-		pcr_value[digest_index] = (uint8_t)hex_value;
-	}
-	return CHARRA_RC_SUCCESS;
+        // convert byte in string representation to byte as uint8_t
+        char byte_as_string[3] = {0};
+        // copy substring into other string because otherwise strtoul
+        // would read more than one byte
+        memcpy(byte_as_string, hex_index, 2);
+        byte_as_string[2] = '\0';
+        errno = 0;
+        char* eol = NULL;
+        uint32_t hex_value = strtoul(byte_as_string, &eol, 16);
+        if (eol == byte_as_string || errno != 0 || hex_value > 255) {
+            return CHARRA_RC_ERROR;
+        }
+        pcr_value[digest_index] = (uint8_t)hex_value;
+    }
+    return CHARRA_RC_SUCCESS;
 }
 
 char* find_end_of_line(char* start, char* end) {
-	for (char* c = start; c < end; c++) {
-		if (*c == '\n') {
-			return c;
-		}
-	} // loop ends when end of file or end of line is reached
-	return end;
+    for (char* c = start; c < end; c++) {
+        if (*c == '\n') {
+            return c;
+        }
+    }  // loop ends when end of file or end of line is reached
+    return end;
 }
 
 int parse_pcr_index(char* index_start) {
-	errno = 0;
-	char* end = NULL;
-	int pcr_index = strtoul(index_start, &end, 10); // parse digits as index
-	if (end == index_start || errno != 0 || pcr_index >= TPM2_MAX_PCRS) {
-		return -1;
-	}
-	return pcr_index;
+    errno = 0;
+    char* end = NULL;
+    int pcr_index = strtoul(index_start, &end, 10);  // parse digits as index
+    if (end == index_start || errno != 0 || pcr_index >= TPM2_MAX_PCRS) {
+        return -1;
+    }
+    return pcr_index;
 }

--- a/src/util/tpm2_util.c
+++ b/src/util/tpm2_util.c
@@ -30,245 +30,245 @@
 #include "../common/charra_log.h"
 
 TSS2_RC tpm2_create_primary_key_rsa2048(
-	ESYS_CONTEXT* ctx, ESYS_TR* primary_handle, TPM2B_PUBLIC** out_public) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+        ESYS_CONTEXT* ctx, ESYS_TR* primary_handle, TPM2B_PUBLIC** out_public) {
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* verify input parameters */
-	if (ctx == NULL) {
-		error_msg = "Bad ESAPI context.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	} else if (primary_handle == NULL) {
-		error_msg = "Bad primary key handle.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	}
+    /* verify input parameters */
+    if (ctx == NULL) {
+        error_msg = "Bad ESAPI context.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    } else if (primary_handle == NULL) {
+        error_msg = "Bad primary key handle.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    }
 
-	/* authenticate at user/storage hierarchy */
-	TPM2B_AUTH authValueSH = {.size = 0, .buffer = {0}};
-	if ((r = Esys_TR_SetAuth(ctx, ESYS_TR_RH_OWNER, &authValueSH)) !=
-		TSS2_RC_SUCCESS) {
-		error_msg = "Esys_TR_SetAuth.";
-		goto error;
-	}
+    /* authenticate at user/storage hierarchy */
+    TPM2B_AUTH authValueSH = {.size = 0, .buffer = {0}};
+    if ((r = Esys_TR_SetAuth(ctx, ESYS_TR_RH_OWNER, &authValueSH)) !=
+            TSS2_RC_SUCCESS) {
+        error_msg = "Esys_TR_SetAuth.";
+        goto error;
+    }
 
-	/* prepare primary key sensitive part */
-	TPM2B_AUTH authValuePK = {.size = 0, .buffer = {0}};
-	TPM2B_SENSITIVE_CREATE inSensitivePrimary = {.size = 0,
-		.sensitive = {
-			.userAuth = authValuePK,
-			.data = {.size = 0, .buffer = {0}},
-		}};
+    /* prepare primary key sensitive part */
+    TPM2B_AUTH authValuePK = {.size = 0, .buffer = {0}};
+    TPM2B_SENSITIVE_CREATE inSensitivePrimary = {.size = 0,
+            .sensitive = {
+                    .userAuth = authValuePK,
+                    .data = {.size = 0, .buffer = {0}},
+            }};
 
-	/* prepare primary key public part */
-	TPM2B_PUBLIC inPublic = {
-		.size = 0,
-		.publicArea =
-			{
-				.type = TPM2_ALG_RSA,
-				.nameAlg = TPM2_ALG_SHA256,
-				.objectAttributes =
-					(TPMA_OBJECT_USERWITHAUTH | TPMA_OBJECT_RESTRICTED |
-						TPMA_OBJECT_SIGN_ENCRYPT | TPMA_OBJECT_FIXEDTPM |
-						TPMA_OBJECT_FIXEDPARENT |
-						TPMA_OBJECT_SENSITIVEDATAORIGIN),
-				.authPolicy =
-					{
-						.size = 0,
-					},
-				.parameters.rsaDetail =
-					{
-						.symmetric =
-							{
-								.algorithm = TPM2_ALG_NULL,
-								.keyBits.aes = 128,
-								.mode.aes = TPM2_ALG_CFB,
-							},
-						.scheme =
-							{
-								.scheme = TPM2_ALG_RSAPSS,
-								.details = {.rsassa = {.hashAlg =
-														   TPM2_ALG_SHA256}},
+    /* prepare primary key public part */
+    /* clang-format off */
+    TPM2B_PUBLIC inPublic = {
+        .size = 0,
+        .publicArea = {
+            .type = TPM2_ALG_RSA,
+            .nameAlg = TPM2_ALG_SHA256,
+            .objectAttributes =
+                (TPMA_OBJECT_USERWITHAUTH | TPMA_OBJECT_RESTRICTED |
+                    TPMA_OBJECT_SIGN_ENCRYPT | TPMA_OBJECT_FIXEDTPM |
+                    TPMA_OBJECT_FIXEDPARENT |
+                    TPMA_OBJECT_SENSITIVEDATAORIGIN),
+            .authPolicy = {
+                .size = 0,
+            },
+            .parameters.rsaDetail = {
+                .symmetric = {
+                    .algorithm = TPM2_ALG_NULL,
+                    .keyBits.aes = 128,
+                    .mode.aes = TPM2_ALG_CFB,
+                },
+                .scheme = {
+                        .scheme = TPM2_ALG_RSAPSS,
+                        .details = {
+                            .rsassa = {
+                                .hashAlg = TPM2_ALG_SHA256,
+                            },
+                        },
+                    },
+                .keyBits = 2048,
+                .exponent = 0,
+            },
+            .unique.rsa = {
+                .size = 0,
+                .buffer = {0},
+            },
+        },
+    };
+    /* clang-format on */
 
-							},
-						.keyBits = 2048,
-						.exponent = 0,
-					},
-				.unique.rsa =
-					{
-						.size = 0,
-						.buffer = {0},
-					},
-			},
-	};
+    /* declare/define all needed in and out parameters */
+    TPM2B_DATA outsideInfo = {.size = 0, .buffer = {0}};
+    TPML_PCR_SELECTION creationPCR = {.count = 0};
 
-	/* declare/define all needed in and out parameters */
-	TPM2B_DATA outsideInfo = {.size = 0, .buffer = {0}};
-	TPML_PCR_SELECTION creationPCR = {.count = 0};
+    if ((r = Esys_CreatePrimary(ctx, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
+                 ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublic,
+                 &outsideInfo, &creationPCR, primary_handle, out_public, NULL,
+                 NULL, NULL)) != TSS2_RC_SUCCESS) {
+        error_msg = "Esys_CreatePrimary";
+        goto error;
+    } else {
+        charra_log_info("Primary Key created successfully.");
+    }
 
-	if ((r = Esys_CreatePrimary(ctx, ESYS_TR_RH_OWNER, ESYS_TR_PASSWORD,
-			 ESYS_TR_NONE, ESYS_TR_NONE, &inSensitivePrimary, &inPublic,
-			 &outsideInfo, &creationPCR, primary_handle, out_public, NULL, NULL,
-			 NULL)) != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_CreatePrimary";
-		goto error;
-	} else {
-		charra_log_info("Primary Key created successfully.");
-	}
-
-	return TSS2_RC_SUCCESS;
+    return TSS2_RC_SUCCESS;
 
 error:
-	if (error_msg != NULL) {
-		charra_log_error("%s", error_msg);
-	}
+    if (error_msg != NULL) {
+        charra_log_error("%s", error_msg);
+    }
 
-	return r;
+    return r;
 }
 
 TSS2_RC tpm2_store_key_in_nvram(ESYS_CONTEXT* ctx, const ESYS_TR* key_handle) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* verify input parameters */
-	if (ctx == NULL) {
-		error_msg = "Bad ESAPI context.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	} else if (key_handle == NULL) {
-		error_msg = "Bad key handle.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	}
+    /* verify input parameters */
+    if (ctx == NULL) {
+        error_msg = "Bad ESAPI context.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    } else if (key_handle == NULL) {
+        error_msg = "Bad key handle.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    }
 
-	/* store key persistently */
-	ESYS_TR primaryPersistentHandle = ESYS_TR_NONE;
-	// TPM2_HANDLE nvPersistentHandle = TPM2_PERSISTENT_FIRST;
-	TPMI_DH_PERSISTENT nvPersistentHandle = TPM2_PERSISTENT_FIRST;
-	if ((r = Esys_EvictControl(ctx, ESYS_TR_RH_OWNER, *key_handle,
-			 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, nvPersistentHandle,
-			 &primaryPersistentHandle)) != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_EvictControl";
-		goto error;
-	} else {
-		charra_log_info("Primary Key successfully stored in NVRAM.");
-	}
+    /* store key persistently */
+    ESYS_TR primaryPersistentHandle = ESYS_TR_NONE;
+    // TPM2_HANDLE nvPersistentHandle = TPM2_PERSISTENT_FIRST;
+    TPMI_DH_PERSISTENT nvPersistentHandle = TPM2_PERSISTENT_FIRST;
+    if ((r = Esys_EvictControl(ctx, ESYS_TR_RH_OWNER, *key_handle,
+                 ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
+                 nvPersistentHandle, &primaryPersistentHandle)) !=
+            TSS2_RC_SUCCESS) {
+        error_msg = "Esys_EvictControl";
+        goto error;
+    } else {
+        charra_log_info("Primary Key successfully stored in NVRAM.");
+    }
 
-	return TSS2_RC_SUCCESS;
+    return TSS2_RC_SUCCESS;
 
 error:
-	if (error_msg != NULL) {
-		charra_log_error("%s", error_msg);
-	}
+    if (error_msg != NULL) {
+        charra_log_error("%s", error_msg);
+    }
 
-	return r;
+    return r;
 }
 
 TSS2_RC tpm2_pcr_extend(ESYS_CONTEXT* ctx, const uint32_t pcr_idx,
-	const TPML_DIGEST_VALUES* digests) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+        const TPML_DIGEST_VALUES* digests) {
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* verify input parameters */
-	if (ctx == NULL) {
-		error_msg = "Bad ESAPI context.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	}
+    /* verify input parameters */
+    if (ctx == NULL) {
+        error_msg = "Bad ESAPI context.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    }
 
-	r = Esys_PCR_Extend(
-		ctx, pcr_idx, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, digests);
+    r = Esys_PCR_Extend(ctx, pcr_idx, ESYS_TR_PASSWORD, ESYS_TR_NONE,
+            ESYS_TR_NONE, digests);
 
-	/*ERROR CHECK*/
-	if (r != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_PCR_Extend";
-		goto error;
-	}
+    /*ERROR CHECK*/
+    if (r != TSS2_RC_SUCCESS) {
+        error_msg = "Esys_PCR_Extend";
+        goto error;
+    }
 
-	return TSS2_RC_SUCCESS;
+    return TSS2_RC_SUCCESS;
 
 error:
-	if (error_msg != NULL) {
-		charra_log_error("%s", error_msg);
-	}
+    if (error_msg != NULL) {
+        charra_log_error("%s", error_msg);
+    }
 
-	return r;
+    return r;
 }
 
 TSS2_RC tpm2_get_random(
-	ESYS_CONTEXT* ctx, const uint32_t len, TPM2B_DIGEST** random_bytes) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+        ESYS_CONTEXT* ctx, const uint32_t len, TPM2B_DIGEST** random_bytes) {
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* verify input parameters */
-	if (ctx == NULL) {
-		error_msg = "Bad ESAPI context.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	} else if (random_bytes == NULL || *random_bytes != NULL) {
-		error_msg = "Bad reference to random bytes (NULL pointer).";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	}
+    /* verify input parameters */
+    if (ctx == NULL) {
+        error_msg = "Bad ESAPI context.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    } else if (random_bytes == NULL || *random_bytes != NULL) {
+        error_msg = "Bad reference to random bytes (NULL pointer).";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    }
 
-	/* get random bytes */
-	r = Esys_GetRandom(
-		ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, len, random_bytes);
+    /* get random bytes */
+    r = Esys_GetRandom(
+            ctx, ESYS_TR_NONE, ESYS_TR_NONE, ESYS_TR_NONE, len, random_bytes);
 
-	/*ERROR CHECK*/
-	if (r != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_GetRandom";
-		goto error;
-	}
+    /*ERROR CHECK*/
+    if (r != TSS2_RC_SUCCESS) {
+        error_msg = "Esys_GetRandom";
+        goto error;
+    }
 
-	return TSS2_RC_SUCCESS;
+    return TSS2_RC_SUCCESS;
 
 error:
-	if (error_msg != NULL) {
-		charra_log_error("%s", error_msg);
-	}
+    if (error_msg != NULL) {
+        charra_log_error("%s", error_msg);
+    }
 
-	return r;
+    return r;
 }
 
 TSS2_RC tpm2_quote(ESYS_CONTEXT* ctx, const ESYS_TR sign_key_handle,
-	const TPML_PCR_SELECTION* pcr_selection, const TPM2B_DATA* qualifying_data,
-	TPM2B_ATTEST** attest_buf, TPMT_SIGNATURE** signature) {
-	TSS2_RC r = TSS2_RC_SUCCESS;
-	char* error_msg = NULL;
+        const TPML_PCR_SELECTION* pcr_selection,
+        const TPM2B_DATA* qualifying_data, TPM2B_ATTEST** attest_buf,
+        TPMT_SIGNATURE** signature) {
+    TSS2_RC r = TSS2_RC_SUCCESS;
+    char* error_msg = NULL;
 
-	/* verify input parameters */
-	if (ctx == NULL) {
-		error_msg = "Bad ESAPI context.";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	}
+    /* verify input parameters */
+    if (ctx == NULL) {
+        error_msg = "Bad ESAPI context.";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    }
 
-	/* check whether size limit is exceeded */
-	if (qualifying_data->size > sizeof(TPMT_HA)) {
-		error_msg = "Size of qualifying data exceeded (max = sizeof(TPMT_HA)";
-		r = TSS2_ESYS_RC_BAD_VALUE;
-		goto error;
-	}
+    /* check whether size limit is exceeded */
+    if (qualifying_data->size > sizeof(TPMT_HA)) {
+        error_msg = "Size of qualifying data exceeded (max = sizeof(TPMT_HA)";
+        r = TSS2_ESYS_RC_BAD_VALUE;
+        goto error;
+    }
 
-	/* do the TPM quote*/
-	TPMT_SIG_SCHEME sig_scheme = {.scheme = TPM2_ALG_NULL};
-	r = Esys_Quote(ctx, sign_key_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
-		ESYS_TR_NONE, qualifying_data, &sig_scheme, pcr_selection, attest_buf,
-		signature);
-	/* ERROR CHECK */
-	if (r != TSS2_RC_SUCCESS) {
-		error_msg = "Esys_Quote";
-		goto error;
-	}
+    /* do the TPM quote*/
+    TPMT_SIG_SCHEME sig_scheme = {.scheme = TPM2_ALG_NULL};
+    r = Esys_Quote(ctx, sign_key_handle, ESYS_TR_PASSWORD, ESYS_TR_NONE,
+            ESYS_TR_NONE, qualifying_data, &sig_scheme, pcr_selection,
+            attest_buf, signature);
+    /* ERROR CHECK */
+    if (r != TSS2_RC_SUCCESS) {
+        error_msg = "Esys_Quote";
+        goto error;
+    }
 
-	return TSS2_RC_SUCCESS;
+    return TSS2_RC_SUCCESS;
 
 error:
-	if (error_msg != NULL) {
-		charra_log_error("%s", error_msg);
-	}
+    if (error_msg != NULL) {
+        charra_log_error("%s", error_msg);
+    }
 
-	return r;
+    return r;
 }

--- a/src/util/tpm2_util.h
+++ b/src/util/tpm2_util.h
@@ -34,7 +34,7 @@
  * @return TSS2_RC The TSS return code.
  */
 TSS2_RC tpm2_create_primary_key_rsa2048(
-	ESYS_CONTEXT* ctx, ESYS_TR* primary_handle, TPM2B_PUBLIC** out_public);
+        ESYS_CONTEXT* ctx, ESYS_TR* primary_handle, TPM2B_PUBLIC** out_public);
 
 /**
  * @brief Stores a key in the TPM NVRAM under the first available NV index.
@@ -54,7 +54,7 @@ TSS2_RC tpm2_store_key_in_nvram(ESYS_CONTEXT* ctx, const ESYS_TR* key_handle);
  * @return TSS2_RC The TSS return code.
  */
 TSS2_RC tpm2_pcr_extend(ESYS_CONTEXT* ctx, const uint32_t pcr_idx,
-	const TPML_DIGEST_VALUES* digests);
+        const TPML_DIGEST_VALUES* digests);
 
 /**
  * @brief Generates random bytes using the TPM 2.0.
@@ -65,7 +65,7 @@ TSS2_RC tpm2_pcr_extend(ESYS_CONTEXT* ctx, const uint32_t pcr_idx,
  * @return TSS2_RC The TSS return code.
  */
 TSS2_RC tpm2_get_random(
-	ESYS_CONTEXT* ctx, const uint32_t len, TPM2B_DIGEST** random_bytes);
+        ESYS_CONTEXT* ctx, const uint32_t len, TPM2B_DIGEST** random_bytes);
 
 /**
  * @brief Executes a TPM quote operation.
@@ -80,7 +80,8 @@ TSS2_RC tpm2_get_random(
  * @return TSS2_RC The TSS return code.
  */
 TSS2_RC tpm2_quote(ESYS_CONTEXT* ctx, const ESYS_TR sign_key_handle,
-	const TPML_PCR_SELECTION* pcr_selection, const TPM2B_DATA* qualifyingData,
-	TPM2B_ATTEST** attest, TPMT_SIGNATURE** signature);
+        const TPML_PCR_SELECTION* pcr_selection,
+        const TPM2B_DATA* qualifyingData, TPM2B_ATTEST** attest,
+        TPMT_SIGNATURE** signature);
 
 #endif /* TPM2_UTIL_H */

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -58,11 +58,11 @@ coap_log_t coap_log_level = LOG_INFO;
 charra_log_t charra_log_level = CHARRA_LOG_INFO;
 
 /* config */
-char dst_host[16] = "127.0.0.1";	 // 15 characters for IPv4 plus \0
-unsigned int dst_port = 5683;		 // default port
-#define COAP_IO_PROCESS_TIME_MS 2000 // CoAP IO process time in milliseconds
+char dst_host[16] = "127.0.0.1";      // 15 characters for IPv4 plus \0
+unsigned int dst_port = 5683;         // default port
+#define COAP_IO_PROCESS_TIME_MS 2000  // CoAP IO process time in milliseconds
 #define PERIODIC_ATTESTATION_WAIT_TIME_S                                       \
-	2 // Wait time between attestations in seconds
+    2  // Wait time between attestations in seconds
 static const bool USE_TPM_FOR_RANDOM_NONCE_GENERATION = false;
 
 #define TPM_SIG_KEY_ID_LEN 14
@@ -71,11 +71,11 @@ static const bool USE_TPM_FOR_RANDOM_NONCE_GENERATION = false;
 static uint8_t tpm_pcr_selection[TPM2_MAX_PCRS] = {0, 1, 2, 3, 4, 5, 6, 7, 10};
 static uint32_t tpm_pcr_selection_len = 9;
 uint16_t attestation_response_timeout =
-	30; // timeout when waiting for attestation answer in seconds
+        30;  // timeout when waiting for attestation answer in seconds
 char* reference_pcr_file_path = "reference-pcrs.txt";
 bool use_ima_event_log = false;
 char* ima_event_log_path =
-	"/sys/kernel/security/ima/binary_runtime_measurements";
+        "/sys/kernel/security/ima/binary_runtime_measurements";
 
 // for DTLS-PSK
 bool use_dtls_psk = false;
@@ -99,11 +99,11 @@ bool dtls_rpk_verify_peer_public_key = true;
 static void handle_sigint(int signum);
 
 static CHARRA_RC create_attestation_request(
-	msg_attestation_request_dto* attestation_request);
+        msg_attestation_request_dto* attestation_request);
 
 static coap_response_t coap_attest_handler(struct coap_context_t* context,
-	coap_session_t* session, coap_pdu_t* sent, coap_pdu_t* received,
-	const coap_mid_t mid);
+        coap_session_t* session, coap_pdu_t* sent, coap_pdu_t* received,
+        const coap_mid_t mid);
 
 /* --- static variables --------------------------------------------------- */
 
@@ -113,331 +113,333 @@ static msg_attestation_response_dto last_response = {0};
 /* --- main --------------------------------------------------------------- */
 
 int main(int argc, char** argv) {
-	CHARRA_RC result = EXIT_FAILURE;
+    CHARRA_RC result = EXIT_FAILURE;
 
-	/* handle SIGINT */
-	signal(SIGINT, handle_sigint);
+    /* handle SIGINT */
+    signal(SIGINT, handle_sigint);
 
-	/* check environment variables */
-	charra_log_level_from_str(
-		(const char*)getenv("LOG_LEVEL_CHARRA"), &charra_log_level);
-	charra_coap_log_level_from_str(
-		(const char*)getenv("LOG_LEVEL_COAP"), &coap_log_level);
+    /* check environment variables */
+    charra_log_level_from_str(
+            (const char*)getenv("LOG_LEVEL_CHARRA"), &charra_log_level);
+    charra_coap_log_level_from_str(
+            (const char*)getenv("LOG_LEVEL_COAP"), &coap_log_level);
 
-	/* initialize structures to pass to the CLI parser */
-	cli_config cli_config = {
-		.caller = VERIFIER,
-		.common_config =
-			{
-				.charra_log_level = &charra_log_level,
-				.coap_log_level = &coap_log_level,
-				.port = &dst_port,
-				.use_dtls_psk = &use_dtls_psk,
-				.dtls_psk_key = &dtls_psk_key,
-				.use_dtls_rpk = &use_dtls_rpk,
-				.dtls_rpk_private_key_path = &dtls_rpk_private_key_path,
-				.dtls_rpk_public_key_path = &dtls_rpk_public_key_path,
-				.dtls_rpk_peer_public_key_path = &dtls_rpk_peer_public_key_path,
-				.dtls_rpk_verify_peer_public_key =
-					&dtls_rpk_verify_peer_public_key,
-			},
-		.verifier_config =
-			{
-				.dst_host = dst_host,
-				.timeout = &attestation_response_timeout,
-				.reference_pcr_file_path = &reference_pcr_file_path,
-				.tpm_pcr_selection = tpm_pcr_selection,
-				.tpm_pcr_selection_len = &tpm_pcr_selection_len,
-				.use_ima_event_log = &use_ima_event_log,
-				.ima_event_log_path = &ima_event_log_path,
-				.dtls_psk_identity = &dtls_psk_identity,
-			},
-	};
+    /* initialize structures to pass to the CLI parser */
+    /* clang-format off */
+    cli_config cli_config = {
+        .caller = VERIFIER,
+        .common_config = {
+            .charra_log_level = &charra_log_level,
+            .coap_log_level = &coap_log_level,
+            .port = &dst_port,
+            .use_dtls_psk = &use_dtls_psk,
+            .dtls_psk_key = &dtls_psk_key,
+            .use_dtls_rpk = &use_dtls_rpk,
+            .dtls_rpk_private_key_path =
+                    &dtls_rpk_private_key_path,
+            .dtls_rpk_public_key_path =
+                    &dtls_rpk_public_key_path,
+            .dtls_rpk_peer_public_key_path =
+                    &dtls_rpk_peer_public_key_path,
+            .dtls_rpk_verify_peer_public_key =
+                    &dtls_rpk_verify_peer_public_key,
+        },
+        .verifier_config = {
+            .dst_host = dst_host,
+            .timeout = &attestation_response_timeout,
+            .reference_pcr_file_path = &reference_pcr_file_path,
+            .tpm_pcr_selection = tpm_pcr_selection,
+            .tpm_pcr_selection_len = &tpm_pcr_selection_len,
+            .use_ima_event_log = &use_ima_event_log,
+            .ima_event_log_path = &ima_event_log_path,
+            .dtls_psk_identity = &dtls_psk_identity,
+        },
+    };
+    /* clang-format on */
 
-	/* set log level before parsing CLI to be able to print errors. */
-	charra_log_set_level(charra_log_level);
-	coap_set_log_level(coap_log_level);
+    /* set log level before parsing CLI to be able to print errors. */
+    charra_log_set_level(charra_log_level);
+    coap_set_log_level(coap_log_level);
 
-	/* parse CLI arguments */
-	if ((result = parse_command_line_arguments(argc, argv, &cli_config)) != 0) {
-		// 1 means help message was displayed (thus exit), -1 means error
-		return (result == 1) ? CHARRA_RC_SUCCESS : CHARRA_RC_CLI_ERROR;
-	}
+    /* parse CLI arguments */
+    if ((result = parse_command_line_arguments(argc, argv, &cli_config)) != 0) {
+        // 1 means help message was displayed (thus exit), -1 means error
+        return (result == 1) ? CHARRA_RC_SUCCESS : CHARRA_RC_CLI_ERROR;
+    }
 
-	/* set CHARRA and libcoap log levels again in case CLI changed these */
-	charra_log_set_level(charra_log_level);
-	coap_set_log_level(coap_log_level);
+    /* set CHARRA and libcoap log levels again in case CLI changed these */
+    charra_log_set_level(charra_log_level);
+    coap_set_log_level(coap_log_level);
 
-	charra_log_debug("[" LOG_NAME "] Verifier Configuration:");
-	charra_log_debug("[" LOG_NAME "]     Destination port: %d", dst_port);
-	charra_log_debug("[" LOG_NAME "]     Destination host: %s", dst_host);
-	charra_log_debug("[" LOG_NAME
-					 "]     Timeout when waiting for attestation response: %ds",
-		attestation_response_timeout);
-	charra_log_debug("[" LOG_NAME "]     Reference PCR file path: '%s'",
-		reference_pcr_file_path);
-	charra_log_debug("[" LOG_NAME "]     PCR selection with length %d:",
-		tpm_pcr_selection_len);
-	charra_log_log_raw(CHARRA_LOG_DEBUG, "                                                      ");
-	for (uint32_t i = 0; i < tpm_pcr_selection_len; i++) {
-		if (i != tpm_pcr_selection_len - 1) {
-			charra_log_log_raw(CHARRA_LOG_DEBUG, "%d, ", tpm_pcr_selection[i]);
-		} else {
-			charra_log_log_raw(CHARRA_LOG_DEBUG, "%d\n", tpm_pcr_selection[i]);
-		}
-	}
-	charra_log_debug("[" LOG_NAME "]     IMA event log attestation enabled: %s",
-		(use_ima_event_log == true) ? "true" : "false");
-	if (use_ima_event_log) {
-		charra_log_debug(
-			"[" LOG_NAME "]         IMA event log path: '%s'", ima_event_log_path);
-	}
-	charra_log_debug("[" LOG_NAME "]     DTLS with PSK enabled: %s",
-		(use_dtls_psk == true) ? "true" : "false");
-	if (use_dtls_psk) {
-		charra_log_debug("[" LOG_NAME "]         Pre-shared key: '%s'",
-			dtls_psk_key);
-		charra_log_debug("[" LOG_NAME "]         Identity: '%s'",
-			dtls_psk_identity);
-	}
-	charra_log_debug("[" LOG_NAME "]     DTLS-RPK enabled: %s",
-		(use_dtls_rpk == true) ? "true" : "false");
-	if (use_dtls_rpk) {
-		charra_log_debug("[" LOG_NAME
-						 "]         Private key path: '%s'",
-			dtls_rpk_private_key_path);
-		charra_log_debug("[" LOG_NAME
-						 "]         Public key path: '%s'",
-			dtls_rpk_public_key_path);
-		charra_log_debug("[" LOG_NAME
-						 "]         Peers' public key path: '%s'",
-			dtls_rpk_peer_public_key_path);
-	}
+    charra_log_debug("[" LOG_NAME "] Verifier Configuration:");
+    charra_log_debug("[" LOG_NAME "]     Destination port: %d", dst_port);
+    charra_log_debug("[" LOG_NAME "]     Destination host: %s", dst_host);
+    charra_log_debug("[" LOG_NAME
+                     "]     Timeout when waiting for attestation response: %ds",
+            attestation_response_timeout);
+    charra_log_debug("[" LOG_NAME "]     Reference PCR file path: '%s'",
+            reference_pcr_file_path);
+    charra_log_debug("[" LOG_NAME "]     PCR selection with length %d:",
+            tpm_pcr_selection_len);
+    charra_log_log_raw(CHARRA_LOG_DEBUG,
+            "                                                      ");
+    for (uint32_t i = 0; i < tpm_pcr_selection_len; i++) {
+        if (i != tpm_pcr_selection_len - 1) {
+            charra_log_log_raw(CHARRA_LOG_DEBUG, "%d, ", tpm_pcr_selection[i]);
+        } else {
+            charra_log_log_raw(CHARRA_LOG_DEBUG, "%d\n", tpm_pcr_selection[i]);
+        }
+    }
+    charra_log_debug("[" LOG_NAME "]     IMA event log attestation enabled: %s",
+            (use_ima_event_log == true) ? "true" : "false");
+    if (use_ima_event_log) {
+        charra_log_debug("[" LOG_NAME "]         IMA event log path: '%s'",
+                ima_event_log_path);
+    }
+    charra_log_debug("[" LOG_NAME "]     DTLS with PSK enabled: %s",
+            (use_dtls_psk == true) ? "true" : "false");
+    if (use_dtls_psk) {
+        charra_log_debug(
+                "[" LOG_NAME "]         Pre-shared key: '%s'", dtls_psk_key);
+        charra_log_debug(
+                "[" LOG_NAME "]         Identity: '%s'", dtls_psk_identity);
+    }
+    charra_log_debug("[" LOG_NAME "]     DTLS-RPK enabled: %s",
+            (use_dtls_rpk == true) ? "true" : "false");
+    if (use_dtls_rpk) {
+        charra_log_debug("[" LOG_NAME "]         Private key path: '%s'",
+                dtls_rpk_private_key_path);
+        charra_log_debug("[" LOG_NAME "]         Public key path: '%s'",
+                dtls_rpk_public_key_path);
+        charra_log_debug("[" LOG_NAME "]         Peers' public key path: '%s'",
+                dtls_rpk_peer_public_key_path);
+    }
 
-	/* set varaibles here such that they are valid in case of an 'goto cleanup'
-	 */
-	coap_context_t* coap_context = NULL;
-	coap_session_t* coap_session = NULL;
-	coap_optlist_t* coap_options = NULL;
-	uint8_t* req_buf = NULL; // TODO make dynamic
+    /* set varaibles here such that they are valid in case of an 'goto cleanup'
+     */
+    coap_context_t* coap_context = NULL;
+    coap_session_t* coap_session = NULL;
+    coap_optlist_t* coap_options = NULL;
+    uint8_t* req_buf = NULL;  // TODO(any): make dynamic
 
-	if (use_dtls_psk && use_dtls_rpk) {
-		charra_log_error(
-			"[" LOG_NAME "] Configuration enables both DTSL with PSK "
-			"and DTSL with PKI. Aborting!");
-		goto cleanup;
-	}
+    if (use_dtls_psk && use_dtls_rpk) {
+        charra_log_error(
+                "[" LOG_NAME "] Configuration enables both DTSL with PSK "
+                "and DTSL with PKI. Aborting!");
+        goto cleanup;
+    }
 
-	if (use_dtls_psk || use_dtls_rpk) {
-		// print TLS version when in debug mode
-		coap_show_tls_version(LOG_DEBUG);
-	}
+    if (use_dtls_psk || use_dtls_rpk) {
+        // print TLS version when in debug mode
+        coap_show_tls_version(LOG_DEBUG);
+    }
 
-	if (use_dtls_psk && !coap_dtls_is_supported()) {
-		charra_log_error("[" LOG_NAME "] CoAP does not support DTLS but the "
-						 "configuration enables DTLS. Aborting!");
-		goto cleanup;
-	}
+    if (use_dtls_psk && !coap_dtls_is_supported()) {
+        charra_log_error("[" LOG_NAME "] CoAP does not support DTLS but the "
+                         "configuration enables DTLS. Aborting!");
+        goto cleanup;
+    }
 
-	/* create CoAP context */
+    /* create CoAP context */
 
-	charra_log_info("[" LOG_NAME "] Initializing CoAP in block-wise mode.");
-	if ((coap_context = charra_coap_new_context(true)) == NULL) {
-		charra_log_error("[" LOG_NAME "] Cannot create CoAP context.");
-		result = CHARRA_RC_COAP_ERROR;
-		goto cleanup;
-	}
+    charra_log_info("[" LOG_NAME "] Initializing CoAP in block-wise mode.");
+    if ((coap_context = charra_coap_new_context(true)) == NULL) {
+        charra_log_error("[" LOG_NAME "] Cannot create CoAP context.");
+        result = CHARRA_RC_COAP_ERROR;
+        goto cleanup;
+    }
 
-	/* register CoAP response handler */
-	charra_log_info("[" LOG_NAME "] Registering CoAP response handler.");
-	coap_register_response_handler(coap_context, coap_attest_handler);
+    /* register CoAP response handler */
+    charra_log_info("[" LOG_NAME "] Registering CoAP response handler.");
+    coap_register_response_handler(coap_context, coap_attest_handler);
 
-	if (use_dtls_psk) {
-		charra_log_info(
-			"[" LOG_NAME "] Creating CoAP client session using DTLS with PSK.");
-		if ((coap_session = charra_coap_new_client_session_psk(coap_context,
-				 dst_host, dst_port, COAP_PROTO_DTLS, dtls_psk_identity,
-				 (uint8_t*)dtls_psk_key, strlen(dtls_psk_key))) == NULL) {
-			charra_log_error(
-				"[" LOG_NAME
-				"] Cannot create client session based on DTLS-PSK.");
-			result = CHARRA_RC_ERROR;
-			goto cleanup;
-		}
-	} else if (use_dtls_rpk) {
-		charra_log_info(
-			"[" LOG_NAME "] Creating CoAP client session using DTLS-RPK.");
-		coap_dtls_pki_t dtls_pki = {0};
+    if (use_dtls_psk) {
+        charra_log_info("[" LOG_NAME
+                        "] Creating CoAP client session using DTLS with PSK.");
+        if ((coap_session = charra_coap_new_client_session_psk(coap_context,
+                     dst_host, dst_port, COAP_PROTO_DTLS, dtls_psk_identity,
+                     (uint8_t*)dtls_psk_key, strlen(dtls_psk_key))) == NULL) {
+            charra_log_error(
+                    "[" LOG_NAME
+                    "] Cannot create client session based on DTLS-PSK.");
+            result = CHARRA_RC_ERROR;
+            goto cleanup;
+        }
+    } else if (use_dtls_rpk) {
+        charra_log_info(
+                "[" LOG_NAME "] Creating CoAP client session using DTLS-RPK.");
+        coap_dtls_pki_t dtls_pki = {0};
 
-		result = charra_coap_setup_dtls_pki_for_rpk(&dtls_pki,
-			dtls_rpk_private_key_path, dtls_rpk_public_key_path,
-			dtls_rpk_peer_public_key_path, dtls_rpk_verify_peer_public_key);
-		if (result != CHARRA_RC_SUCCESS) {
-			charra_log_error(
-				"[" LOG_NAME "] Error while setting up DTLS-RPK structure.");
-			goto cleanup;
-		}
+        result = charra_coap_setup_dtls_pki_for_rpk(&dtls_pki,
+                dtls_rpk_private_key_path, dtls_rpk_public_key_path,
+                dtls_rpk_peer_public_key_path, dtls_rpk_verify_peer_public_key);
+        if (result != CHARRA_RC_SUCCESS) {
+            charra_log_error("[" LOG_NAME
+                             "] Error while setting up DTLS-RPK structure.");
+            goto cleanup;
+        }
 
-		if ((coap_session = charra_coap_new_client_session_pki(coap_context,
-				 dst_host, dst_port, COAP_PROTO_DTLS, &dtls_pki)) == NULL) {
-			charra_log_error(
-				"[" LOG_NAME
-				"] Cannot create client session based on DTLS-RPK.");
-			result = CHARRA_RC_ERROR;
-			goto cleanup;
-		}
-	} else {
-		charra_log_info(
-			"[" LOG_NAME "] Creating CoAP client session using UDP.");
-		if ((coap_session = charra_coap_new_client_session(
-				 coap_context, dst_host, dst_port, COAP_PROTO_UDP)) == NULL) {
-			charra_log_error(
-				"[" LOG_NAME "] Cannot create client session based on UDP.");
-			result = CHARRA_RC_COAP_ERROR;
-			goto cleanup;
-		}
-	}
+        if ((coap_session = charra_coap_new_client_session_pki(coap_context,
+                     dst_host, dst_port, COAP_PROTO_DTLS, &dtls_pki)) == NULL) {
+            charra_log_error(
+                    "[" LOG_NAME
+                    "] Cannot create client session based on DTLS-RPK.");
+            result = CHARRA_RC_ERROR;
+            goto cleanup;
+        }
+    } else {
+        charra_log_info(
+                "[" LOG_NAME "] Creating CoAP client session using UDP.");
+        if ((coap_session = charra_coap_new_client_session(coap_context,
+                     dst_host, dst_port, COAP_PROTO_UDP)) == NULL) {
+            charra_log_error("[" LOG_NAME
+                             "] Cannot create client session based on UDP.");
+            result = CHARRA_RC_COAP_ERROR;
+            goto cleanup;
+        }
+    }
 
-	/* define needed variables */
-	msg_attestation_request_dto req = {0};
-	uint32_t req_buf_len = 0;
-	coap_pdu_t* pdu = NULL;
-	coap_mid_t mid = COAP_INVALID_MID;
-	int coap_io_process_time = -1;
+    /* define needed variables */
+    msg_attestation_request_dto req = {0};
+    uint32_t req_buf_len = 0;
+    coap_pdu_t* pdu = NULL;
+    coap_mid_t mid = COAP_INVALID_MID;
+    int coap_io_process_time = -1;
 
-	/* create CoAP option for content type */
-	uint8_t coap_mediatype_cbor_buf[4] = {0};
-	unsigned int coap_mediatype_cbor_buf_len = 0;
-	if ((coap_mediatype_cbor_buf_len = coap_encode_var_safe(
-			 coap_mediatype_cbor_buf, sizeof(coap_mediatype_cbor_buf),
-			 COAP_MEDIATYPE_APPLICATION_CBOR)) == 0) {
-		charra_log_error(
-			"[" LOG_NAME "] Cannot create option for CONTENT_TYPE.");
-		result = CHARRA_RC_COAP_ERROR;
-		goto cleanup;
-	}
+    /* create CoAP option for content type */
+    uint8_t coap_mediatype_cbor_buf[4] = {0};
+    unsigned int coap_mediatype_cbor_buf_len = 0;
+    if ((coap_mediatype_cbor_buf_len = coap_encode_var_safe(
+                 coap_mediatype_cbor_buf, sizeof(coap_mediatype_cbor_buf),
+                 COAP_MEDIATYPE_APPLICATION_CBOR)) == 0) {
+        charra_log_error(
+                "[" LOG_NAME "] Cannot create option for CONTENT_TYPE.");
+        result = CHARRA_RC_COAP_ERROR;
+        goto cleanup;
+    }
 
-	/* enter  periodic attestation loop */
-	// TODO enable periodic attestations
-	// charra_log_info("[" LOG_NAME "] Entering periodic attestation loop.");
-	// while (!quit) {
-	// 	/* cleanup */
-	// 	memset(&req, 0, sizeof(req));
-	// 	if (coap_options != NULL) {
-	// 		coap_delete_optlist(coap_options);
-	// 		coap_options = NULL;
-	// 	}
+    /* enter  periodic attestation loop */
+    // TODO(any): Enable periodic attestations.
+    // charra_log_info("[" LOG_NAME "] Entering periodic attestation loop.");
+    // while (!quit) {
+    //     /* cleanup */
+    //     memset(&req, 0, sizeof(req));
+    //     if (coap_options != NULL) {
+    //         coap_delete_optlist(coap_options);
+    //         coap_options = NULL;
+    //     }
 
-	/* create attestation request */
-	charra_log_info("[" LOG_NAME "] Creating attestation request.");
-	if ((result = create_attestation_request(&req)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Cannot create attestation request.");
-		goto cleanup;
-	} else {
-		/* store request data */
-		last_request = req;
-	}
+    /* create attestation request */
+    charra_log_info("[" LOG_NAME "] Creating attestation request.");
+    if ((result = create_attestation_request(&req)) != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Cannot create attestation request.");
+        goto cleanup;
+    } else {
+        /* store request data */
+        last_request = req;
+    }
 
-	/* marshal attestation request */
-	charra_log_info(
-		"[" LOG_NAME "] Marshaling attestation request data to CBOR.");
-	if ((result = charra_marshal_attestation_request(
-			 &req, &req_buf_len, &req_buf)) != CHARRA_RC_SUCCESS) {
-		charra_log_error(
-			"[" LOG_NAME "] Marshaling attestation request data failed.");
-		goto cleanup;
-	}
+    /* marshal attestation request */
+    charra_log_info(
+            "[" LOG_NAME "] Marshaling attestation request data to CBOR.");
+    if ((result = charra_marshal_attestation_request(
+                 &req, &req_buf_len, &req_buf)) != CHARRA_RC_SUCCESS) {
+        charra_log_error(
+                "[" LOG_NAME "] Marshaling attestation request data failed.");
+        goto cleanup;
+    }
 
-	/* CoAP options */
-	charra_log_info("[" LOG_NAME "] Adding CoAP option URI_PATH.");
-	if (coap_insert_optlist(
-			&coap_options, coap_new_optlist(COAP_OPTION_URI_PATH, 6,
-							   (const uint8_t*)"attest")) != 1) {
-		charra_log_error("[" LOG_NAME "] Cannot add CoAP option URI_PATH.");
-		result = CHARRA_RC_COAP_ERROR;
-		goto cleanup;
-	}
-	charra_log_info("[" LOG_NAME "] Adding CoAP option CONTENT_TYPE.");
-	if (coap_insert_optlist(&coap_options,
-			coap_new_optlist(COAP_OPTION_CONTENT_TYPE,
-				coap_mediatype_cbor_buf_len, coap_mediatype_cbor_buf)) != 1) {
-		charra_log_error("[" LOG_NAME "] Cannot add CoAP option CONTENT_TYPE.");
-		result = CHARRA_RC_COAP_ERROR;
-		goto cleanup;
-	}
+    /* CoAP options */
+    charra_log_info("[" LOG_NAME "] Adding CoAP option URI_PATH.");
+    if (coap_insert_optlist(
+                &coap_options, coap_new_optlist(COAP_OPTION_URI_PATH, 6,
+                                       (const uint8_t*)"attest")) != 1) {
+        charra_log_error("[" LOG_NAME "] Cannot add CoAP option URI_PATH.");
+        result = CHARRA_RC_COAP_ERROR;
+        goto cleanup;
+    }
+    charra_log_info("[" LOG_NAME "] Adding CoAP option CONTENT_TYPE.");
+    if (coap_insert_optlist(
+                &coap_options, coap_new_optlist(COAP_OPTION_CONTENT_TYPE,
+                                       coap_mediatype_cbor_buf_len,
+                                       coap_mediatype_cbor_buf)) != 1) {
+        charra_log_error("[" LOG_NAME "] Cannot add CoAP option CONTENT_TYPE.");
+        result = CHARRA_RC_COAP_ERROR;
+        goto cleanup;
+    }
 
-	/* new CoAP request PDU */
-	charra_log_info("[" LOG_NAME "] Creating request PDU.");
-	if ((pdu = charra_coap_new_request(coap_session, COAP_MESSAGE_TYPE_CON,
-			 COAP_REQUEST_FETCH, &coap_options, req_buf, req_buf_len)) ==
-		NULL) {
-		charra_log_error("[" LOG_NAME "] Cannot create request PDU.");
-		result = CHARRA_RC_ERROR;
-		goto cleanup;
-	}
+    /* new CoAP request PDU */
+    charra_log_info("[" LOG_NAME "] Creating request PDU.");
+    if ((pdu = charra_coap_new_request(coap_session, COAP_MESSAGE_TYPE_CON,
+                 COAP_REQUEST_FETCH, &coap_options, req_buf, req_buf_len)) ==
+            NULL) {
+        charra_log_error("[" LOG_NAME "] Cannot create request PDU.");
+        result = CHARRA_RC_ERROR;
+        goto cleanup;
+    }
 
-	/* set timeout length */
-	coap_fixed_point_t coap_timeout = {attestation_response_timeout, 0};
-	coap_session_set_ack_timeout(coap_session, coap_timeout);
+    /* set timeout length */
+    coap_fixed_point_t coap_timeout = {attestation_response_timeout, 0};
+    coap_session_set_ack_timeout(coap_session, coap_timeout);
 
-	/* send CoAP PDU */
-	charra_log_info("[" LOG_NAME "] Sending CoAP message.");
-	if ((mid = coap_send_large(coap_session, pdu)) == COAP_INVALID_MID) {
-		charra_log_error("[" LOG_NAME "] Cannot send CoAP message.");
-		result = CHARRA_RC_COAP_ERROR;
-		goto cleanup;
-	}
+    /* send CoAP PDU */
+    charra_log_info("[" LOG_NAME "] Sending CoAP message.");
+    if ((mid = coap_send_large(coap_session, pdu)) == COAP_INVALID_MID) {
+        charra_log_error("[" LOG_NAME "] Cannot send CoAP message.");
+        result = CHARRA_RC_COAP_ERROR;
+        goto cleanup;
+    }
 
-	/* processing and waiting for response */
-	charra_log_info("[" LOG_NAME "] Processing and waiting for response ...");
-	uint16_t response_wait_time = 0;
-	while (!processing_response && !coap_can_exit(coap_context)) {
-		/* process CoAP I/O */
-		if ((coap_io_process_time = coap_io_process(
-				 coap_context, COAP_IO_PROCESS_TIME_MS)) == -1) {
-			charra_log_error(
-				"[" LOG_NAME "] Error during CoAP I/O processing.");
-			result = CHARRA_RC_COAP_ERROR;
-			goto cleanup;
-		}
-		/* This wait time is not 100% accurate, it only includes the elapsed
-		 * time inside the coap_io_process function. But should be good enough.
-		 */
-		response_wait_time += coap_io_process_time;
-		if (response_wait_time >= (attestation_response_timeout * 1000)) {
-			charra_log_error("[" LOG_NAME
-							 "] Timeout after %d ms while waiting for or "
-							 "processing attestation response.",
-				response_wait_time);
-			result = CHARRA_RC_TIMEOUT;
-			goto cleanup;
-		}
-	}
+    /* processing and waiting for response */
+    charra_log_info("[" LOG_NAME "] Processing and waiting for response ...");
+    uint16_t response_wait_time = 0;
+    while (!processing_response && !coap_can_exit(coap_context)) {
+        /* process CoAP I/O */
+        if ((coap_io_process_time = coap_io_process(
+                     coap_context, COAP_IO_PROCESS_TIME_MS)) == -1) {
+            charra_log_error(
+                    "[" LOG_NAME "] Error during CoAP I/O processing.");
+            result = CHARRA_RC_COAP_ERROR;
+            goto cleanup;
+        }
+        /* This wait time is not 100% accurate, it only includes the elapsed
+         * time inside the coap_io_process function. But should be good enough.
+         */
+        response_wait_time += coap_io_process_time;
+        if (response_wait_time >= (attestation_response_timeout * 1000)) {
+            charra_log_error("[" LOG_NAME
+                             "] Timeout after %d ms while waiting for or "
+                             "processing attestation response.",
+                    response_wait_time);
+            result = CHARRA_RC_TIMEOUT;
+            goto cleanup;
+        }
+    }
 
-	// normal exit from processing loop, set result to result of attestation
-	result = attestation_rc;
+    // normal exit from processing loop, set result to result of attestation
+    result = attestation_rc;
 
-	/* wait until next attestation */
-	// TODO enable periodic attestations
-	// charra_log_info(
-	// 	"[" LOG_NAME
-	// 	"] Waiting %d seconds until next attestation request ...",
-	// 	PERIODIC_ATTESTATION_WAIT_TIME_S);
-	// sleep(PERIODIC_ATTESTATION_WAIT_TIME_S);
-	// }
+    /* wait until next attestation */
+    // TODO(any): Enable periodic attestations.
+    //     charra_log_info(
+    //             "[" LOG_NAME
+    //             "] Waiting %d seconds until next attestation request ...",
+    //             PERIODIC_ATTESTATION_WAIT_TIME_S);
+    //     sleep(PERIODIC_ATTESTATION_WAIT_TIME_S);
+    // }
 
 cleanup:
-	/* free CoAP memory */
-	charra_free_if_not_null_ex(coap_options, coap_delete_optlist);
-	charra_free_if_not_null_ex(coap_session, coap_session_release);
-	charra_free_if_not_null_ex(coap_context, coap_free_context);
+    /* free CoAP memory */
+    charra_free_if_not_null_ex(coap_options, coap_delete_optlist);
+    charra_free_if_not_null_ex(coap_session, coap_session_release);
+    charra_free_if_not_null_ex(coap_context, coap_free_context);
 
-	/* free variables */
-	charra_free_if_not_null(req_buf);
+    /* free variables */
+    charra_free_if_not_null(req_buf);
 
-	coap_cleanup();
+    coap_cleanup();
 
-	return result;
+    return result;
 }
 
 /* --- function definitions ----------------------------------------------- */
@@ -445,337 +447,342 @@ cleanup:
 static void handle_sigint(int signum CHARRA_UNUSED) { quit = true; }
 
 static CHARRA_RC create_attestation_request(
-	msg_attestation_request_dto* attestation_request) {
-	CHARRA_RC err = CHARRA_RC_ERROR;
+        msg_attestation_request_dto* attestation_request) {
+    CHARRA_RC err = CHARRA_RC_ERROR;
 
-	/* generate nonce */
-	uint32_t nonce_len = 20;
-	uint8_t nonce[nonce_len];
-	if (USE_TPM_FOR_RANDOM_NONCE_GENERATION) {
-		if ((err = charra_random_bytes_from_tpm(nonce_len, nonce) !=
-				   CHARRA_RC_SUCCESS)) {
-			charra_log_error("Could not get random bytes from TPM for nonce.");
-			return err;
-		}
-	} else {
-		if ((err = charra_random_bytes(nonce_len, nonce) !=
-				   CHARRA_RC_SUCCESS)) {
-			charra_log_error("Could not get random bytes for nonce.");
-			return err;
-		}
-	}
-	charra_log_info("[" LOG_NAME "] Generated nonce of length %d:", nonce_len);
-	charra_print_hex(CHARRA_LOG_INFO, nonce_len, nonce,
-		"                                                  0x", "\n", false);
+    /* generate nonce */
+    const uint32_t nonce_len = 20;
+    uint8_t nonce[nonce_len];
+    if (USE_TPM_FOR_RANDOM_NONCE_GENERATION) {
+        if ((err = charra_random_bytes_from_tpm(nonce_len, nonce) !=
+                    CHARRA_RC_SUCCESS)) {
+            charra_log_error("Could not get random bytes from TPM for nonce.");
+            return err;
+        }
+    } else {
+        if ((err = charra_random_bytes(nonce_len, nonce) !=
+                    CHARRA_RC_SUCCESS)) {
+            charra_log_error("Could not get random bytes for nonce.");
+            return err;
+        }
+    }
+    charra_log_info("[" LOG_NAME "] Generated nonce of length %d:", nonce_len);
+    charra_print_hex(CHARRA_LOG_INFO, nonce_len, nonce,
+            "                                                  0x", "\n",
+            false);
 
-	/* build attestation request */
-	msg_attestation_request_dto req = {
-		.hello = false,
-		.sig_key_id_len = TPM_SIG_KEY_ID_LEN,
-		.sig_key_id = {0}, // must be memcpy'd, see below
-		.nonce_len = nonce_len,
-		.nonce = {0}, // must be memcpy'd, see below
-		.pcr_selections_len = 1,
-		.pcr_selections = {{
-			.tcg_hash_alg_id = TPM2_ALG_SHA256,
-			.pcrs_len = tpm_pcr_selection_len,
-			.pcrs = {0} // must be memcpy'd, see below
-		}},
-		.event_log_path_len =
-			(use_ima_event_log) ? strlen(ima_event_log_path) : 0,
-		.event_log_path =
-			(use_ima_event_log) ? (uint8_t*)ima_event_log_path : NULL,
-	};
-	memcpy(req.sig_key_id, TPM_SIG_KEY_ID, TPM_SIG_KEY_ID_LEN);
-	memcpy(req.nonce, nonce, nonce_len);
-	memcpy(req.pcr_selections->pcrs, tpm_pcr_selection, tpm_pcr_selection_len);
+    /* build attestation request */
+    msg_attestation_request_dto req = {
+            .hello = false,
+            .sig_key_id_len = TPM_SIG_KEY_ID_LEN,
+            .sig_key_id = {0},  // must be memcpy'd, see below
+            .nonce_len = nonce_len,
+            .nonce = {0},  // must be memcpy'd, see below
+            .pcr_selections_len = 1,
+            .pcr_selections = {{
+                    .tcg_hash_alg_id = TPM2_ALG_SHA256,
+                    .pcrs_len = tpm_pcr_selection_len,
+                    .pcrs = {0}  // must be memcpy'd, see below
+            }},
+            .event_log_path_len =
+                    (use_ima_event_log) ? strlen(ima_event_log_path) : 0,
+            .event_log_path =
+                    (use_ima_event_log) ? (uint8_t*)ima_event_log_path : NULL,
+    };
+    memcpy(req.sig_key_id, TPM_SIG_KEY_ID, TPM_SIG_KEY_ID_LEN);
+    memcpy(req.nonce, nonce, nonce_len);
+    memcpy(req.pcr_selections->pcrs, tpm_pcr_selection, tpm_pcr_selection_len);
 
-	/* set output param(s) */
-	*attestation_request = req;
+    /* set output param(s) */
+    *attestation_request = req;
 
-	/* return result */
-	return CHARRA_RC_SUCCESS;
+    /* return result */
+    return CHARRA_RC_SUCCESS;
 }
 
 /* --- resource handler definitions --------------------------------------- */
 
 static coap_response_t coap_attest_handler(
-	struct coap_context_t* context CHARRA_UNUSED,
-	coap_session_t* session CHARRA_UNUSED, coap_pdu_t* sent CHARRA_UNUSED,
-	coap_pdu_t* in, const coap_mid_t mid CHARRA_UNUSED) {
-	int coap_r = 0;
-	TSS2_RC tss_r = 0;
+        struct coap_context_t* context CHARRA_UNUSED,
+        coap_session_t* session CHARRA_UNUSED, coap_pdu_t* sent CHARRA_UNUSED,
+        coap_pdu_t* in, const coap_mid_t mid CHARRA_UNUSED) {
+    int coap_r = 0;
+    TSS2_RC tss_r = 0;
 
-	ESYS_TR sig_key_handle = ESYS_TR_NONE;
-	TPMT_TK_VERIFIED* validation = NULL;
+    ESYS_TR sig_key_handle = ESYS_TR_NONE;
+    TPMT_TK_VERIFIED* validation = NULL;
 
-	processing_response = true;
+    processing_response = true;
 
-	charra_log_info(
-		"[" LOG_NAME "] Resource '%s': Received message.", "attest");
-	coap_show_pdu(LOG_DEBUG, in);
+    charra_log_info(
+            "[" LOG_NAME "] Resource '%s': Received message.", "attest");
+    coap_show_pdu(LOG_DEBUG, in);
 
-	/* --- receive incoming data --- */
+    /* --- receive incoming data --- */
 
-	/* get data */
-	size_t data_len = 0;
-	const uint8_t* data = NULL;
-	size_t data_offset = 0;
-	size_t data_total_len = 0;
-	if ((coap_r = coap_get_data_large(
-			 in, &data_len, &data, &data_offset, &data_total_len)) == 0) {
-		charra_log_error("[" LOG_NAME "] Could not get CoAP PDU data.");
-		attestation_rc = CHARRA_RC_ERROR;
-		goto cleanup;
-	} else {
-		charra_log_info(
-			"[" LOG_NAME "] Received data of length %zu.", data_len);
-		charra_log_info("[" LOG_NAME "] Received data of total length %zu.",
-			data_total_len);
-	}
+    /* get data */
+    size_t data_len = 0;
+    const uint8_t* data = NULL;
+    size_t data_offset = 0;
+    size_t data_total_len = 0;
+    if ((coap_r = coap_get_data_large(
+                 in, &data_len, &data, &data_offset, &data_total_len)) == 0) {
+        charra_log_error("[" LOG_NAME "] Could not get CoAP PDU data.");
+        attestation_rc = CHARRA_RC_ERROR;
+        goto cleanup;
+    } else {
+        charra_log_info(
+                "[" LOG_NAME "] Received data of length %zu.", data_len);
+        charra_log_info("[" LOG_NAME "] Received data of total length %zu.",
+                data_total_len);
+    }
 
-	/* unmarshal data */
-	charra_log_info("[" LOG_NAME "] Parsing received CBOR data.");
-	msg_attestation_response_dto res = {0};
-	if ((attestation_rc = charra_unmarshal_attestation_response(
-			 data_len, data, &res)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Could not parse CBOR data.");
-		goto cleanup;
-	}
+    /* unmarshal data */
+    charra_log_info("[" LOG_NAME "] Parsing received CBOR data.");
+    msg_attestation_response_dto res = {0};
+    if ((attestation_rc = charra_unmarshal_attestation_response(
+                 data_len, data, &res)) != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Could not parse CBOR data.");
+        goto cleanup;
+    }
 
-	/* store last response */
-	last_response = res;
+    /* store last response */
+    last_response = res;
 
-	/* verify data */
-	if (res.attestation_data_len > sizeof(TPM2B_ATTEST)) {
-		charra_log_error(
-			"[" LOG_NAME
-			"] Length of attestation data exceeds maximum allowed size.");
-		attestation_rc = CHARRA_RC_ERROR;
-		goto cleanup;
-	}
-	if (res.tpm2_signature_len > sizeof(TPMT_SIGNATURE)) {
-		charra_log_error(
-			"[" LOG_NAME "] Length of signature exceeds maximum allowed size.");
-		attestation_rc = CHARRA_RC_ERROR;
-		goto cleanup;
-	}
+    /* verify data */
+    if (res.attestation_data_len > sizeof(TPM2B_ATTEST)) {
+        charra_log_error(
+                "[" LOG_NAME
+                "] Length of attestation data exceeds maximum allowed size.");
+        attestation_rc = CHARRA_RC_ERROR;
+        goto cleanup;
+    }
+    if (res.tpm2_signature_len > sizeof(TPMT_SIGNATURE)) {
+        charra_log_error("[" LOG_NAME
+                         "] Length of signature exceeds maximum allowed size.");
+        attestation_rc = CHARRA_RC_ERROR;
+        goto cleanup;
+    }
 
-	/* --- verify TPM Quote --- */
-	charra_log_info("[" LOG_NAME "] Starting verification.");
+    /* --- verify TPM Quote --- */
+    charra_log_info("[" LOG_NAME "] Starting verification.");
 
-	/* initialize ESAPI */
-	ESYS_CONTEXT* esys_ctx = NULL;
-	TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
-	if ((tss_r = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
-		TSS2_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Tss2_TctiLdr_Initialize.");
-		attestation_rc = CHARRA_RC_ERROR;
-		goto cleanup;
-	}
-	if ((tss_r = Esys_Initialize(&esys_ctx, tcti_ctx, NULL)) !=
-		TSS2_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Esys_Initialize.");
-		attestation_rc = CHARRA_RC_ERROR;
-		goto cleanup;
-	}
+    /* initialize ESAPI */
+    ESYS_CONTEXT* esys_ctx = NULL;
+    TSS2_TCTI_CONTEXT* tcti_ctx = NULL;
+    if ((tss_r = Tss2_TctiLdr_Initialize(getenv("CHARRA_TCTI"), &tcti_ctx)) !=
+            TSS2_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Tss2_TctiLdr_Initialize.");
+        attestation_rc = CHARRA_RC_ERROR;
+        goto cleanup;
+    }
+    if ((tss_r = Esys_Initialize(&esys_ctx, tcti_ctx, NULL)) !=
+            TSS2_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Esys_Initialize.");
+        attestation_rc = CHARRA_RC_ERROR;
+        goto cleanup;
+    }
 
-	/* load TPM key */
-	TPM2B_PUBLIC* tpm2_public_key = (TPM2B_PUBLIC*)res.tpm2_public_key;
-	charra_log_info("[" LOG_NAME "] Loading TPM key.");
-	if ((attestation_rc = charra_load_external_public_key(esys_ctx,
-			 tpm2_public_key, &sig_key_handle)) != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Loading external public key failed.");
-		goto cleanup;
-	} else {
-		charra_log_info("[" LOG_NAME "] External public key loaded.");
-	}
+    /* load TPM key */
+    TPM2B_PUBLIC* tpm2_public_key = (TPM2B_PUBLIC*)res.tpm2_public_key;
+    charra_log_info("[" LOG_NAME "] Loading TPM key.");
+    if ((attestation_rc = charra_load_external_public_key(esys_ctx,
+                 tpm2_public_key, &sig_key_handle)) != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Loading external public key failed.");
+        goto cleanup;
+    } else {
+        charra_log_info("[" LOG_NAME "] External public key loaded.");
+    }
 
-	/* prepare verification */
-	charra_log_info("[" LOG_NAME "] Preparing TPM Quote verification.");
-	TPM2B_ATTEST attest = {0};
-	attest.size = res.attestation_data_len;
-	memcpy(
-		attest.attestationData, res.attestation_data, res.attestation_data_len);
-	TPMT_SIGNATURE signature = {0};
-	memcpy(&signature, res.tpm2_signature, res.tpm2_signature_len);
+    /* prepare verification */
+    charra_log_info("[" LOG_NAME "] Preparing TPM Quote verification.");
+    TPM2B_ATTEST attest = {0};
+    attest.size = res.attestation_data_len;
+    memcpy(attest.attestationData, res.attestation_data,
+            res.attestation_data_len);
+    TPMT_SIGNATURE signature = {0};
+    memcpy(&signature, res.tpm2_signature, res.tpm2_signature_len);
 
-	/* --- verify attestation signature --- */
-	bool attestation_result_signature = false;
-	{
-		charra_log_info(
-			"[" LOG_NAME "] Verifying TPM Quote signature with TPM ...");
-		/* verify attestation signature with TPM */
-		if ((attestation_rc = charra_verify_tpm2_quote_signature_with_tpm(
-				 esys_ctx, sig_key_handle, TPM2_ALG_SHA256, &attest, &signature,
-				 &validation)) == CHARRA_RC_SUCCESS) {
-			charra_log_info(
-				"[" LOG_NAME "]     => TPM Quote signature is valid!");
-			attestation_result_signature = true;
-		} else {
-			charra_log_error(
-				"[" LOG_NAME "]     => TPM Quote signature is NOT valid!");
-		}
-	}
-	{
-		/* convert TPM public key to mbedTLS public key */
-		charra_log_info(
-			"[" LOG_NAME
-			"] Converting TPM public key to mbedTLS public key ...");
-		mbedtls_rsa_context mbedtls_rsa_pub_key = {0};
-		if ((attestation_rc = charra_crypto_tpm_pub_key_to_mbedtls_pub_key(
-				 tpm2_public_key, &mbedtls_rsa_pub_key)) != CHARRA_RC_SUCCESS) {
-			charra_log_error("[" LOG_NAME "] mbedTLS RSA error");
-			goto cleanup;
-		}
+    /* --- verify attestation signature --- */
+    bool attestation_result_signature = false;
+    {
+        charra_log_info(
+                "[" LOG_NAME "] Verifying TPM Quote signature with TPM ...");
+        /* verify attestation signature with TPM */
+        if ((attestation_rc = charra_verify_tpm2_quote_signature_with_tpm(
+                     esys_ctx, sig_key_handle, TPM2_ALG_SHA256, &attest,
+                     &signature, &validation)) == CHARRA_RC_SUCCESS) {
+            charra_log_info(
+                    "[" LOG_NAME "]     => TPM Quote signature is valid!");
+            attestation_result_signature = true;
+        } else {
+            charra_log_error(
+                    "[" LOG_NAME "]     => TPM Quote signature is NOT valid!");
+        }
+    }
+    {
+        /* convert TPM public key to mbedTLS public key */
+        charra_log_info(
+                "[" LOG_NAME
+                "] Converting TPM public key to mbedTLS public key ...");
+        mbedtls_rsa_context mbedtls_rsa_pub_key = {0};
+        if ((attestation_rc = charra_crypto_tpm_pub_key_to_mbedtls_pub_key(
+                     tpm2_public_key, &mbedtls_rsa_pub_key)) !=
+                CHARRA_RC_SUCCESS) {
+            charra_log_error("[" LOG_NAME "] mbedTLS RSA error");
+            goto cleanup;
+        }
 
-		/* verify attestation signature with mbedTLS */
-		charra_log_info(
-			"[" LOG_NAME "] Verifying TPM Quote signature with mbedTLS ...");
-		if ((attestation_rc = charra_crypto_rsa_verify_signature(
-				 &mbedtls_rsa_pub_key, MBEDTLS_MD_SHA256, res.attestation_data,
-				 (size_t)res.attestation_data_len,
-				 signature.signature.rsapss.sig.buffer)) == CHARRA_RC_SUCCESS) {
-			charra_log_info(
-				"[" LOG_NAME "]     => TPM Quote signature is valid!");
-		} else {
-			charra_log_error(
-				"[" LOG_NAME "]     => TPM Quote signature is NOT valid!");
-		}
-		mbedtls_rsa_free(&mbedtls_rsa_pub_key);
-	}
+        /* verify attestation signature with mbedTLS */
+        charra_log_info("[" LOG_NAME
+                        "] Verifying TPM Quote signature with mbedTLS ...");
+        if ((attestation_rc = charra_crypto_rsa_verify_signature(
+                     &mbedtls_rsa_pub_key, MBEDTLS_MD_SHA256,
+                     res.attestation_data, (size_t)res.attestation_data_len,
+                     signature.signature.rsapss.sig.buffer)) ==
+                CHARRA_RC_SUCCESS) {
+            charra_log_info(
+                    "[" LOG_NAME "]     => TPM Quote signature is valid!");
+        } else {
+            charra_log_error(
+                    "[" LOG_NAME "]     => TPM Quote signature is NOT valid!");
+        }
+        mbedtls_rsa_free(&mbedtls_rsa_pub_key);
+    }
 
-	/* unmarshal attestation data */
-	TPMS_ATTEST attest_struct = {0};
-	attestation_rc = charra_unmarshal_tpm2_quote(
-		res.attestation_data_len, res.attestation_data, &attest_struct);
-	if (attestation_rc != CHARRA_RC_SUCCESS) {
-		charra_log_error("[" LOG_NAME "] Error while unmarshaling TPM2 Quote.");
-		goto cleanup;
-	}
+    /* unmarshal attestation data */
+    TPMS_ATTEST attest_struct = {0};
+    attestation_rc = charra_unmarshal_tpm2_quote(
+            res.attestation_data_len, res.attestation_data, &attest_struct);
+    if (attestation_rc != CHARRA_RC_SUCCESS) {
+        charra_log_error("[" LOG_NAME "] Error while unmarshaling TPM2 Quote.");
+        goto cleanup;
+    }
 
-	/* --- verify nonce --- */
-	bool attestation_result_nonce = false;
-	{
-		charra_log_info("[" LOG_NAME "] Verifying nonce ...");
+    /* --- verify nonce --- */
+    bool attestation_result_nonce = false;
+    {
+        charra_log_info("[" LOG_NAME "] Verifying nonce ...");
 
-		attestation_result_nonce = charra_verify_tpm2_quote_qualifying_data(
-			last_request.nonce_len, last_request.nonce, &attest_struct);
-		if (attestation_result_nonce == true) {
-			charra_log_info(
-				"[" LOG_NAME
-				"]     => Nonce in TPM Quote is valid! (matches the one sent)");
-		} else {
-			charra_log_error(
-				"[" LOG_NAME "]     => Nonce in TPM Quote is NOT valid! (does "
-				"not match the one sent)");
-		}
-	}
+        attestation_result_nonce = charra_verify_tpm2_quote_qualifying_data(
+                last_request.nonce_len, last_request.nonce, &attest_struct);
+        if (attestation_result_nonce == true) {
+            charra_log_info("[" LOG_NAME "]     => Nonce in TPM Quote is "
+                            "valid! (matches the one sent)");
+        } else {
+            charra_log_error("[" LOG_NAME
+                             "]     => Nonce in TPM Quote is NOT valid! (does "
+                             "not match the one sent)");
+        }
+    }
 
-	/* --- verify PCRs --- */
-	bool attestation_result_pcrs = false;
-	{
-		charra_log_info("[" LOG_NAME "] Verifying PCRs ...");
+    /* --- verify PCRs --- */
+    bool attestation_result_pcrs = false;
+    {
+        charra_log_info("[" LOG_NAME "] Verifying PCRs ...");
 
-		charra_log_info(
-			"[" LOG_NAME "] Actual PCR composite digest from TPM Quote is:");
-		charra_print_hex(CHARRA_LOG_INFO,
-			attest_struct.attested.quote.pcrDigest.size,
-			attest_struct.attested.quote.pcrDigest.buffer,
-			"                                              0x", "\n", false);
+        charra_log_info("[" LOG_NAME
+                        "] Actual PCR composite digest from TPM Quote is:");
+        charra_print_hex(CHARRA_LOG_INFO,
+                attest_struct.attested.quote.pcrDigest.size,
+                attest_struct.attested.quote.pcrDigest.buffer,
+                "                                              0x", "\n",
+                false);
 
-		CHARRA_RC pcr_check =
-			charra_check_pcr_digest_against_reference(reference_pcr_file_path,
-				tpm_pcr_selection, tpm_pcr_selection_len, &attest_struct);
-		if (pcr_check == CHARRA_RC_SUCCESS) {
-			charra_log_info(
-				"[" LOG_NAME "]     => PCR composite digest is valid!");
-			attestation_result_pcrs = true;
-		} else {
-			charra_log_error(
-				"[" LOG_NAME
-				"]     => PCR composite digest is NOT valid! (does "
-				"not match any of the digests from the set of reference PCRs)");
-		}
-	}
+        CHARRA_RC pcr_check = charra_check_pcr_digest_against_reference(
+                reference_pcr_file_path, tpm_pcr_selection,
+                tpm_pcr_selection_len, &attest_struct);
+        if (pcr_check == CHARRA_RC_SUCCESS) {
+            charra_log_info(
+                    "[" LOG_NAME "]     => PCR composite digest is valid!");
+            attestation_result_pcrs = true;
+        } else {
+            charra_log_error(
+                    "[" LOG_NAME
+                    "]     => PCR composite digest is NOT valid! (does "
+                    "not match any of the digests from the set of reference "
+                    "PCRs)");
+        }
+    }
 
-	/* verify event log */
-	// TODO: Implement real verification
-	bool attestation_event_log = true;
-	if (use_ima_event_log) {
-		charra_log_info("[" LOG_NAME "] Verifying event log ...");
-		if (res.event_log_len == 0) {
-			charra_log_error("[" LOG_NAME "] Received no event log altough IMA "
-							 "event log verification is on.");
-			attestation_event_log = false;
-		} else {
-			charra_log_info(
-				"[" LOG_NAME "]     <<< This is to be implemented. >>>");
-			charra_log_info("[" LOG_NAME
-							"]     IMA Event Log size is %d bytes.",
-				res.event_log_len);
-			charra_log_debug("[" LOG_NAME "]     IMA Event Log:");
+    /* verify event log */
+    // TODO(any): Implement real verification.
+    bool attestation_event_log = true;
+    if (use_ima_event_log) {
+        charra_log_info("[" LOG_NAME "] Verifying event log ...");
+        if (res.event_log_len == 0) {
+            charra_log_error("[" LOG_NAME "] Received no event log altough IMA "
+                             "event log verification is on.");
+            attestation_event_log = false;
+        } else {
+            charra_log_info(
+                    "[" LOG_NAME "]     <<< This is to be implemented. >>>");
+            charra_log_info("[" LOG_NAME
+                            "]     IMA Event Log size is %d bytes.",
+                    res.event_log_len);
+            charra_log_debug("[" LOG_NAME "]     IMA Event Log:");
 
-			if (res.event_log_len > 20) {
-				charra_print_hex(CHARRA_LOG_DEBUG, 10, res.event_log,
-					"                                                  0x",
-					"...", false);
-				charra_print_hex(CHARRA_LOG_DEBUG, 10,
-					(res.event_log + res.event_log_len - 10), "", "\n", false);
-			} else if ((res.event_log_len > 0)) {
-				charra_print_hex(CHARRA_LOG_DEBUG, res.event_log_len,
-					res.event_log,
-					"                                                  0x",
-					"\n", false);
-			} else {
-				charra_log_debug("[" LOG_NAME "]     <none>");
-			}
-		}
-	}
+            if (res.event_log_len > 20) {
+                charra_print_hex(CHARRA_LOG_DEBUG, 10, res.event_log,
+                        "                                                  0x",
+                        "...", false);
+                charra_print_hex(CHARRA_LOG_DEBUG, 10,
+                        (res.event_log + res.event_log_len - 10), "", "\n",
+                        false);
+            } else if ((res.event_log_len > 0)) {
+                charra_print_hex(CHARRA_LOG_DEBUG, res.event_log_len,
+                        res.event_log,
+                        "                                                  0x",
+                        "\n", false);
+            } else {
+                charra_log_debug("[" LOG_NAME "]     <none>");
+            }
+        }
+    }
 
-	/* --- output result --- */
+    /* --- output result --- */
 
-	bool attestation_result = attestation_result_signature &&
-							  attestation_result_nonce &&
-							  attestation_result_pcrs && attestation_event_log;
+    bool attestation_result = attestation_result_signature &&
+                              attestation_result_nonce &&
+                              attestation_result_pcrs && attestation_event_log;
 
-	/* print attestation result */
-	charra_log_info("[" LOG_NAME "] +----------------------------+");
-	if (attestation_result) {
-		attestation_rc = CHARRA_RC_SUCCESS;
-		charra_log_info("[" LOG_NAME "] |   ATTESTATION SUCCESSFUL   |");
-	} else {
-		attestation_rc = CHARRA_RC_VERIFICATION_FAILED;
-		charra_log_info("[" LOG_NAME "] |     ATTESTATION FAILED     |");
-	}
-	charra_log_info("[" LOG_NAME "] +----------------------------+");
+    /* print attestation result */
+    charra_log_info("[" LOG_NAME "] +----------------------------+");
+    if (attestation_result) {
+        attestation_rc = CHARRA_RC_SUCCESS;
+        charra_log_info("[" LOG_NAME "] |   ATTESTATION SUCCESSFUL   |");
+    } else {
+        attestation_rc = CHARRA_RC_VERIFICATION_FAILED;
+        charra_log_info("[" LOG_NAME "] |     ATTESTATION FAILED     |");
+    }
+    charra_log_info("[" LOG_NAME "] +----------------------------+");
 
 cleanup:
-	/* flush handles */
-	if (sig_key_handle != ESYS_TR_NONE) {
-		if (Esys_FlushContext(esys_ctx, sig_key_handle) != TSS2_RC_SUCCESS) {
-			charra_log_error(
-				"[" LOG_NAME "] TSS cleanup sig_key_handle failed.");
-		}
-	}
+    /* flush handles */
+    if (sig_key_handle != ESYS_TR_NONE) {
+        if (Esys_FlushContext(esys_ctx, sig_key_handle) != TSS2_RC_SUCCESS) {
+            charra_log_error(
+                    "[" LOG_NAME "] TSS cleanup sig_key_handle failed.");
+        }
+    }
 
-	/* free event log */
-	// TODO: Provide function charra_free_msg_attestation_response_dto()
-	charra_free_if_not_null(res.event_log);
+    /* free event log */
+    // TODO(any): Provide function charra_free_msg_attestation_response_dto().
+    charra_free_if_not_null(res.event_log);
 
-	/* free ESAPI objects */
-	if (validation != NULL) {
-		Esys_Free(validation);
-	}
+    /* free ESAPI objects */
+    if (validation != NULL) {
+        Esys_Free(validation);
+    }
 
-	/* finalize ESAPI & TCTI */
-	if (esys_ctx != NULL) {
-		Esys_Finalize(&esys_ctx);
-	}
-	if (tcti_ctx != NULL) {
-		Tss2_TctiLdr_Finalize(&tcti_ctx);
-	}
+    /* finalize ESAPI & TCTI */
+    if (esys_ctx != NULL) {
+        Esys_Finalize(&esys_ctx);
+    }
+    if (tcti_ctx != NULL) {
+        Tss2_TctiLdr_Finalize(&tcti_ctx);
+    }
 
-	processing_response = false;
-	return COAP_RESPONSE_OK;
+    processing_response = false;
+    return COAP_RESPONSE_OK;
 }


### PR DESCRIPTION
Fixes #58.

- Replaced tabs with spaces for indentation.
- Adapted `.clang-format` and `.editorconfig` files.
- Reformatted some comments.
- Disabled automatic indentation for certain blocks.
- Fixed style of TODO comments.

Signed-off-by: Michael Eckel <michael.eckel@sit.fraunhofer.de>