### PR TITLE
Fixing Makefile and Docker Compose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,111 @@
+<!--
+################################################################################
+# Copyright 2023, Fraunhofer Institute for Secure Information Technology SIT.  #
+# All rights reserved.                                                         #
+# ---------------------------------------------------------------------------- #
+# Author:        Michael Eckel <michael.eckel@sit.fraunhofer.de>               #
+# Date Modified: 2023-05-20T13:37:42+02:00                                     #
+# Date Created:  2019-06-26T09:23:15+02:00                                     #
+################################################################################
+-->
+
+# Changelog
+
+The following lists the changes CHARRA received over time.
+
+## Changelog 2023-05-20
+
+* Fixed `Makefile`
+
+* Fixed Docker Compose
+
+* Externalized building and installation instructions into [`INSTALL.md`](INSTALL.md) and the changelog into [`CHANGELOG.md`](CHANGELOG.md).
+
+* Minor adjustments.
+
+## Changelog 2021-03-17
+
+* Dynamic memory allocation for QCBOR encoded data using *malloc()*.
+  Thanks, @laurencelundblade.
+
+* Fixed some bugs.
+
+* Introduced macros for `free()`'ing heap data.
+
+## Changelog 2021-03-16 (v2)
+
+* Added random nonce generation with mbed TLS in Verifier.
+  Made it configurable whether to use the TPM or mbed TLS to generate the nonce.
+
+* Added media type CBOR to attestation request in Verifier.
+  Credits go to @mrdeep1.
+
+## Changelog 2021-03-16 (v1)
+
+* Updated `README.md` to include building *tpm2software/tpm2-tss* Docker image which CHARRA uses as a basis.
+  Reason: recently, the official *tpm2software/tpm2-tss* Docker images were removed from [Docker Hub](https://hub.docker.com/r/tpm2software/tpm2-tss).
+
+* Added Docker Compose file and description on how to use it to `README.md`.
+
+* Added `.editorconfig` file.
+
+* Using most recent stable versions of *tpm2-tss* and *tpm2-tools*.
+
+* Added compressed CHARRA SVG logo (`*.svgz`). See [charra-logo.svgz](./charra-logo.svgz).
+
+## Changelog 2021-03-10
+
+* Added support for CoAP large/block-wise data transfers, utilizing latest features of [libcoap](https://github.com/obgm/libcoap).
+  This enables CHARRA to send and receive data of arbitrary size.
+  Many thanks to @mrdeep1 for developing and fixing block-wise transfers in *libcoap*!
+
+* Console output/logging can be entirely disabled with the `disable-log` Make switch.
+  Colored logging can be disabled with the `disable-log-color` Make switch.
+  This allows CHARRA to be used in embedded systems.
+  Example:
+
+      make disable-log=1
+      make disable-log-color=1
+
+* For debugging purposes a Make flag `address-sanitizer` was introduced. Example:
+
+      make address-sanitizer=1
+
+* For TPM operations a custom TCTI module can be used.
+  For this purpose, the Make flag `with-tcti` was introduced.
+  If not specified, the default is `mssim`.
+  Use it like:
+
+      make with-tcti=device
+
+* To reduce the binary size, a Make flag `strip` was introduced.
+  It invokes *strip --strip-unneeded* on the resulting binaries.
+  Example:
+
+      make strip=1
+
+* Log levels of CHARRA and *libcoap* can now be specified at runtime, e.g.:
+
+      env LOG_LEVEL_CHARRA=TRACE LOG_LEVEL_COAP=DEBUG bin/verifier
+
+  * Supported CHARRA log levels are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, and `FATAL`.
+
+  * Supported *libcoap* log levels are: `EMERG`, `ALERT`, `CRIT`, `ERR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
+
+* CHARRA `Dockerfile` now uses Ubuntu 20.04 instead of Ubuntu 18.04 as its base image.
+
+* Added tools for debugging to `Dockerfile` (*tmux*, *gdb*, *cgdb*, and *clang-tools*).
+
+* Graceful exit using SIGINT handlers.
+
+* Simplified CoAP handling by introducing wrapper functions for
+*libcoap*.
+
+* Updated `README.md`.
+
+* CHARRA now has a logo, see [charra-logo.svg](./charra-logo.svg), [charra-logo.png](./charra-logo.png), and [charra-logo_small.png](./charra-logo_small.png).
+
+## Changelog 2019-09-19
+
+* Initial version
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 ################################################################################
+# Copyright 2023, Fraunhofer Institute for Secure Information Technology SIT.  #
+# All rights reserved.                                                         #
+# ---------------------------------------------------------------------------- #
 # Main Dockerfile for CHARRA.                                                  #
 # ---------------------------------------------------------------------------- #
 # Author:        Michael Eckel <michael.eckel@sit.fraunhofer.de>               #
-# Date Modified: 2023-04-03T13:37:42+02:00                                     #
+# Date Modified: 2023-05-20T13:37:42+02:00                                     #
 # Date Created:  2019-06-26T09:23:15+02:00                                     #
 # ---------------------------------------------------------------------------- #
 # Hint: Check your Dockerfile at https://www.fromlatest.io/                    #
@@ -26,7 +29,7 @@ LABEL org.opencontainers.image.authors="michael.eckel@sit.fraunhofer.de"
 
 ## --- image specific arguments ------------------------------------------------
 
-ARG user=charra
+ARG user=bob
 ARG uid=1000
 ARG gid=1000
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,192 @@
+<!--
+################################################################################
+# Copyright 2023, Fraunhofer Institute for Secure Information Technology SIT.  #
+# All rights reserved.                                                         #
+# ---------------------------------------------------------------------------- #
+# Author:        Michael Eckel <michael.eckel@sit.fraunhofer.de>               #
+# Date Modified: 2023-05-20T13:37:42+02:00                                     #
+# Date Created:  2019-06-26T09:23:15+02:00                                     #
+################################################################################
+-->
+
+# Build and Run CHARRA
+
+CHARRA comes with a Docker environment and helper scripts to quickly test CHARRA interactively.
+It is also possible to build and run CHARRA manually.
+All commands are to be executed in [Bash](https://www.gnu.org/software/bash/).
+
+## The Docker and Docker Compose Way
+
+The following describes how to run CHARRA in [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
+
+### Preparation
+
+First, Docker and Docker Compose must be installed and .
+The following command are intended for an Ubuntu (amd64) system.
+
+1. Install [Docker](https://docs.docker.com/get-docker/) (and [Docker Compose](https://docs.docker.com/compose/install/)):
+
+       sudo apt update
+       sudo apt install docker.io docker-compose
+
+2. Set group membership to run containers as non-root user:
+
+       sudo groupadd docker
+       sudo usermod -aG docker "${USER}"
+
+3. Restart system (to activate group membership):
+
+       sudo reboot
+
+### Using Docker
+
+Running CHARRA in Docker is the prefered way of running it.
+This way, you do not need to install all the dependencies into your system just to try CHARRA.
+
+1. Build CHARRA container image(s):
+
+       ./docker/build.sh
+
+2. Run the CHARRA interactive development environment container:
+
+       ./docker/run.sh
+
+### Using Docker Compose
+
+1. Build the CHARRA container image(s):
+
+       docker-compose build --build-arg uid="${UID}" --build-arg gid="${UID}"
+
+2. Run the CHARRA interactive development environment container:
+
+       docker-compose run --rm charra-dev-env
+
+<!-- TODO: Uncomment this when verified that it works
+### Run CHARRA Apps in Docker Compose
+
+    docker-compose run --rm -T charra-attester &
+    docker-compose run --rm -T charra-verifier
+-->
+
+## The Manual Way
+
+Please follow the steps in the `Dockerfile` to build and install dependencies manually directly into your system.
+
+## Compile and Run CHARRA
+
+Once all dependencies are installed, or you have the container running, change to the root folder of your local copy of CHARRA (in the container do a `cd ~/charra/`).
+
+1. Compile CHARRA:
+
+       make -j
+
+2. Run CHARRA:
+
+       (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT attester
+
+If you see a message "ATTESTATION SUCCESSFUL", it worked.
+
+
+## Build Arguments
+
+CHARRA comes with some build arguments that you find in the following.
+
+| Argument                   | Default          | Available Options                             |
+| -------------------------- | ---------------- | --------------------------------------------- |
+| `LINK_MODE`                | `dynamic`        | `dynamic`, `static` (*currently not working*) |
+| `ENABLE_ADDRESS_SANITIZER` | `0` (disabled)   | `0` (disabled), != `0` (enabled)              |
+| `ENABLE_PIC`               | `1` (enabled)    | `0` (disabled), != `0` (enabled)              |
+| `TCTI_MODULE`              | `tctildr`        | `tcti-default`, `tcti-cmd`, `tcti-device`, `tcti-libtpms`, `tcti-mssim`, `tcti-pcap`, `tcti-swtpm`, `tctildr` (and other implementations ) |
+| `ENABLE_LOGGING`           | `1` (enabled)    | `0` (disabled), != `0` (enabled) |
+| `ENABLE_LOGGING_COLOR`     | `1` (enabled)    | `0` (disabled), != `0` (enabled) |
+| `ENABLE_STRIPPING`         | `1` (enabled)    | `0` (disabled), != `0` (enabled) |
+
+Example invocation:
+
+    make TCTI_MODULE=mssim ENABLE_LOGGING_COLOR=0 ENABLE_STRIPPING=0
+
+## Troubleshooting and Advanced Usage
+
+This section contains valuable information in case you want to dig a bit deeper and adjust CHARRA's running conditions.
+
+### TPM Simulator
+
+1. Start the TPM Simulator (and remove the state file `NVChip`):
+
+       (cd /tmp ; pkill tpm_server ; rm -f NVChip; /usr/local/bin/tpm_server > /dev/null &)
+
+2. Send TPM *startup* command:
+
+       /usr/local/bin/tpm2_startup -Tmssim --clear
+
+3. Run Attester and Verifier:
+
+       (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT -f bin/attester
+
+If you see a message "ATTESTATION SUCCESSFUL", it worked.
+
+### Debugging
+
+* Clang `scan-build`:
+
+      make clean ; scan-build make
+
+* Valgrind:
+
+      (valgrind --leak-check=full \
+          --show-leak-kinds=all -v \
+          bin/attester \
+          2> attester-valgrind-stderr.log &); \
+      sleep .2 ; \
+      (valgrind --leak-check=full \
+          --show-leak-kinds=all -v \
+          bin/verifier\
+          2> verifier-valgrind-stderr.log) ;\
+      sleep 1 ; \
+      pkill -SIGINT -f bin/attester
+
+* AddressSanitizer (ASan):
+
+      make clean ; make ENABLE_ADDRESS_SANITIZER=1
+      (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT -f bin/attester
+
+### Run Attester and Verifier on Different Devices
+
+The attester and verifier can be used on two different devices.
+To do that, you have to provide an external network for the attester Docker container.
+
+1. Create [macvlan network](https://docs.docker.com/network/macvlan/) for attester Docker container (check your gateway address and replace `x` with the correct number):
+
+       docker network create -d macvlan \
+           --subnet=192.168.x.0/24 \
+           --gateway=192.168.x.1 \
+           -o parent=eth0 pub_net
+
+2. Add `--network` parameter to the `docker run` command in the `docker/run.sh` on the attester device:
+
+       ## run (transient) Docker container
+       /usr/bin/docker run --rm -it \
+           -v "${PWD}/:/home/bob/charra" \
+           --network=pub_net \
+           "${docker_image_fullname}" \
+           "$@"
+
+3. Run the attester Docker container and check the IP address.
+
+4. Put the attester address to the `DST_HOST` in `src/verifier.c` on the verifier device.
+   Rebuild the verifier in the verifier Docker container:
+
+       cd charra
+       make -j
+
+5. Go to `charra` directory and run attester binary in the attester Docker container:
+
+       cd charra
+       bin/attester
+
+6. Run the verifier binary in the verifier docker container:
+
+       /bin/verifier
+
+If you see a message "ATTESTATION SUCCESSFUL", it worked.
+

--- a/README.md
+++ b/README.md
@@ -1,105 +1,43 @@
+<!--
+################################################################################
+# Copyright 2023, Fraunhofer Institute for Secure Information Technology SIT.  #
+# All rights reserved.                                                         #
+# ---------------------------------------------------------------------------- #
+# Author:        Michael Eckel <michael.eckel@sit.fraunhofer.de>               #
+# Date Modified: 2023-05-20T13:37:42+02:00                                     #
+# Date Created:  2019-06-26T09:23:15+02:00                                     #
+################################################################################
+-->
+
 # CHARRA: CHAllenge-Response based Remote Attestation with TPM 2.0
 
 ![CHARRA Logo](charra-logo_small.png)
 
 This is a proof-of-concept implementation of the "Challenge/Response Remote Attestation" interaction model of the [IETF RATS](https://datatracker.ietf.org/wg/rats/about/) [Reference Interaction Models for Remote Attestation Procedures](https://datatracker.ietf.org/doc/draft-ietf-rats-reference-interaction-models/) using TPM 2.0. The [IETF Remote Attestation Procedures (RATS)](https://datatracker.ietf.org/wg/rats/about/) working group standardizes formats for describing assertions/claims about system components and associated evidence; and procedures and protocols to convey these assertions/claims to relying parties. Given the security and privacy sensitive nature of these assertions/claims, the working group specifies approaches to protect this exchanged data.
 
-This proof-of-concept implementation realizes the Attesting Computing Environment—a Computing Environment capable of monitoring and attesting a target Computing Environment—as well as the target Computing Environment itself, as described in the [RATS Architecture](https://datatracker.ietf.org/doc/draft-ietf-rats-architecture/).
+This proof-of-concept implementation realizes the Attesting Computing Environment—a Computing Environment capable of monitoring and attesting a target Computing Environment—as well as the target Computing Environment itself, as described in the [RATS Architecture](https://datatracker.ietf.org/doc/rfc9334/).
 
-## Changelog 2021-03-17
+## Quickstart
 
-* Dynamic memory allocation for QCBOR encoded data using *malloc()*.
-  Thanks, @laurencelundblade.
+The following assumes that [Docker](https://docs.docker.com/get-docker/) (and [Docker Compose](https://docs.docker.com/compose/install/)) are installed and configured on your system.
+Please see [`INSTALL.md`](INSTALL.md) for details, also for manually building CHARRA.
+All commands are to be executed in [Bash](https://www.gnu.org/software/bash/).
 
-* Fixed some bugs.
+For Docker, build the image and run the container with:
 
-* Introduced macros for `free()`'ing heap data.
+    ./docker/build.sh
+    ./docker/run.sh
 
-## Changelog 2021-03-16 (v2)
+With Docker Compose do:
 
-* Added random nonce generation with mbed TLS in Verifier.
-  Made it configurable whether to use the TPM or mbed TLS to generate the nonce.
+    docker-compose build --build-arg uid="${UID}" --build-arg gid="${UID}"
+    docker-compose run --rm charra-dev-env
 
-* Added media type CBOR to attestation request in Verifier.
-  Credits go to @mrdeep1.
+Inside the container, change to the `~/charra/` folder, build it, and run it:
 
-## Changelog 2021-03-16 (v1)
-
-* Updated `README.md` to include building *tpm2software/tpm2-tss* Docker image which CHARRA uses as a basis.
-  Reason: recently, the official *tpm2software/tpm2-tss* Docker images were removed from [Docker Hub](https://hub.docker.com/r/tpm2software/tpm2-tss).
-
-* Added Docker Compose file and description on how to use it to `README.md`.
-
-* Added `.editorconfig` file.
-
-* Using most recent stable versions of *tpm2-tss* and *tpm2-tools*.
-
-* Added compressed CHARRA SVG logo (`*.svgz`). See [charra-logo.svgz](./charra-logo.svgz).
-
-## Changelog 2021-03-10
-
-* Added support for CoAP large/block-wise data transfers, utilizing latest features of [libcoap](https://github.com/obgm/libcoap).
-  This enables CHARRA to send and receive data of arbitrary size.
-  Many thanks to @mrdeep1 for developing and fixing block-wise transfers in *libcoap*!
-
-* Console output/logging can be entirely disabled with the `disable-log` Make switch.
-  Colored logging can be disabled with the `disable-log-color` Make switch.
-  This allows CHARRA to be used in embedded systems.
-  Example:
-
-      make disable-log=1
-      make disable-log-color=1
-
-* For debugging purposes a Make flag `address-sanitizer` was introduced. Example:
-
-      make address-sanitizer=1
-
-* For TPM operations a custom TCTI module can be used.
-  For this purpose, the Make flag `with-tcti` was introduced.
-  If not specified, the default is `mssim`.
-  Use it like:
-
-      make with-tcti=device
-
-* To reduce the binary size, a Make flag `strip` was introduced.
-  It invokes *strip --strip-unneeded* on the resulting binaries.
-  Example:
-
-      make strip=1
-
-* Log levels of CHARRA and *libcoap* can now be specified at runtime, e.g.:
-
-      env LOG_LEVEL_CHARRA=TRACE LOG_LEVEL_COAP=DEBUG bin/verifier
-
-  * Supported CHARRA log levels are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, and `FATAL`.
-
-  * Supported *libcoap* log levels are: `EMERG`, `ALERT`, `CRIT`, `ERR`, `WARNING`, `NOTICE`, `INFO`, and `DEBUG`.
-
-* CHARRA `Dockerfile` now uses Ubuntu 20.04 instead of Ubuntu 18.04 as its base image.
-
-* Added tools for debugging to `Dockerfile` (*tmux*, *gdb*, *cgdb*, and *clang-tools*).
-
-* Graceful exit using SIGINT handlers.
-
-* Simplified CoAP handling by introducing wrapper functions for
-*libcoap*.
-
-* Updated `README.md`.
-
-* CHARRA now has a logo, see [charra-logo.svg](./charra-logo.svg), [charra-logo.png](./charra-logo.png), and [charra-logo_small.png](./charra-logo_small.png).
-
-## Next Steps
-
-* Allow verifier to perform periodic attestations, e.g. perform attestation every 10 seconds.
-* Update documentation. Perhaps externalize building and installation into `INSTALL.md`.
-* Refactor and implement forward-declared (but not yet implemented) functions.
-* Use non-zero reference PCRs.
-* "Extended" *TPM Quote* using TPM audit session(s) and *TPM PCR Read* operations.
-* Make CHARRA a library (`libcharra`) and make *attester* and *verifier* example code in `example` folder.
-* Add `*_free()` functions for all data transfer objects (DTOs).
-* Introduce semantic versioning as CHARRA develops along the way to become stable.
-
-*The order of the list is entirely arbitrary and does not reflect any priorities.*
+    cd ~/charra/
+    make -j
+    (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT attester
 
 ## How it Works: Protocol Flow
 
@@ -120,229 +58,19 @@ The following diagram shows the protocol flow of the CHARRA attestation process.
          |                           attestationResult <= |
          |                                                |
 
-## Build and Run
+## Changelog
 
-CHARRA comes with a Docker test environment and Docker helper scripts to build and run it in Docker.
-It is also possible to build and run CHARRA manually.
-All commands assume to be executed in [Bash](https://www.gnu.org/software/bash/), the Bourne-again shell.
+You find the changelog in [`CHANGELOG.md`](CHANGELOG.md).
 
-### Using Docker
+## Next Steps
 
-Running CHARRA in Docker is the "quickstart" way of running it.
-This way, you do not need to install all the dependencies into your system in order to try CHARRA.
-All steps to get it up and running are described in the following.
+* Allow verifier to perform periodic attestations, e.g., perform attestation every 10 seconds.
+* Refactor and implement forward-declared (but not yet implemented) functions.
+* Use non-zero reference PCRs.
+* "Extended" *TPM Quote* using TPM audit session(s) and *TPM PCR Read* operations.
+* Make CHARRA a library (`libcharra`) and make *attester* and *verifier* example code in `example` folder.
+* Add `*_free()` functions for all data transfer objects (DTOs).
+* Introduce semantic versioning as CHARRA develops along the way to become stable.
 
-#### Build the Docker Base Image
+*The order of the list is entirely arbitrary and does not reflect any priorities.*
 
-The CHARRA `Dockerfile` uses on the official [*tpm2software/tpm2-tss* Docker images](https://github.com/tpm2-software/tpm2-software-container.git) as a basis.
-Recently, these official images were removed from [Docker Hub](https://hub.docker.com/r/tpm2software/tpm2-tss>).
-That is why the Docker base image for CHARRA must now be built manually.
-
-1. Install [Docker](https://docs.docker.com/engine/install/).
-
-2. Install dependencies (*make* and *m4*):
-
-       ## On Ubuntu
-       sudo apt install make m4
-
-       ## On Fedora
-       sudo dnf install make m4
-
-3. Clone the [TPM2 Software Container](https://github.com/tpm2-software/tpm2-software-container) repository:
-
-       git clone 'https://github.com/tpm2-software/tpm2-software-container.git' \
-           'tmp/tpm2-software-container'
-       pushd 'tmp/tpm2-software-container'
-
-4. Create `*.docker` files:
-
-       make
-
-5. Build Docker image:
-
-       docker build -t 'tpm2software/tpm2-tss:ubuntu-20.04' -f ubuntu-20.04.docker .
-       popd
-
-#### Build the CHARRA Docker Image using Docker Compose
-
-1. Install [Docker Compose](https://docs.docker.com/compose/install/).
-
-2. Build the CHARRA image(s):
-
-       docker-compose build --build-arg uid="$UID" --build-arg gid="$UID"
-
-3. Run the CHARRA container:
-
-       docker-compose run --rm charra-dev-env
-
-<!-- TODO: Uncomment this when verified that it works
-### Run CHARRA Apps in Docker Compose
-
-    docker-compose run --rm -T charra-attester &
-    docker-compose run --rm -T charra-verifier
--->
-
-#### Build the CHARRA Docker Image using Docker
-
-1. Build CHARRA Docker image:
-
-       ./docker/build.sh
-
-2. Run CHARRA Docker container:
-
-       ./docker/run.sh
-
-#### Compile and Run CHARRA
-
-1. Compile CHARRA (inside container):
-
-       cd charra/
-       make -j
-
-2. Run CHARRA (inside container):
-
-       (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT attester
-
-If you see "ATTESTATION SUCCESSFUL" you're done. Congratz :-D
-
-### Compile and Run Manually
-
-The provided `Dockerfile` lets you quickly test CHARRA in a Docker environment.
-If you want to run CHARRA bare metal, please refer to this guide here.
-
-#### Compile
-
-The `Dockerfile` provides details on installing all dependencies and should be considered authoritative over this.
-
-1. Install all dependencies that are needed for the [TPM2 TSS](https://github.com/tpm2-software/tpm2-tss/blob/master/INSTALL.md).
-
-2. Install *libcoap*:
-
-       git clone --depth=1 --recursive -b 'develop' \
-           'https://github.com/obgm/libcoap.git' /tmp/libcoap
-       cd /tmp/libcoap
-       ./autogen.sh
-       ./configure --disable-tests --disable-documentation \
-           --disable-manpages --disable-dtls --disable-shared \
-           --enable-fast-install
-       make -j
-       make install
-
-   Make sure that you do not have `libcoap-1-0-dev` installed, as the headers might conflict.
-
-3. Install *mbedtls*:
-
-       git clone --depth=1 --recursive -b 'development' \
-           'https://github.com/ARMmbed/mbedtls.git' /tmp/mbedtls
-       cd /tmp/mbedtls
-       make -j lib SHARED=true
-       make install
-
-4. Install *QCBOR*:
-
-       git clone --depth=1 --recursive -b 'master' \
-           'https://github.com/laurencelundblade/QCBOR.git' /tmp/qcbor
-       cd /tmp/qcbor
-       make -j all so
-       make install install_so
-
-5. Install *t_cose*:
-
-       git clone --depth=1 --recursive -b 'master' \
-           'https://github.com/laurencelundblade/t_cose.git' /tmp/t_cose
-       cd /tmp/t_cose
-       make -j -f Makefile.psa libt_cose.a libt_cose.so
-       make -f Makefile.psa install install_so
-
-6. Compile programs:
-
-       make -j
-
-#### Further Preparation
-
-1. Download and install [IBM's TPM 2.0 Simulator](https://sourceforge.net/projects/ibmswtpm2/).
-
-2. Download and install the [TPM2 Tools](https://github.com/tpm2-software/tpm2-tools).
-
-#### Run
-
-1. Start the TPM Simulator (and remove the state file `NVChip`):
-
-       (cd /tmp ; pkill tpm_server ; rm -f NVChip; /usr/local/bin/tpm_server > /dev/null &)
-
-2. Send TPM *startup* command:
-
-       /usr/local/bin/tpm2_startup -Tmssim --clear
-
-3. Run Attester and Verifier:
-
-       (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT -f bin/attester
-
-If you see "ATTESTATION SUCCESSFUL" you're done. Congratz :-D
-
-## Debugging
-
-* Clang `scan-build`:
-
-      make clean ; scan-build make
-
-* Valgrind:
-
-      (valgrind --leak-check=full \
-          --show-leak-kinds=all -v \
-          bin/attester \
-          2> attester-valgrind-stderr.log &); \
-      sleep .2 ; \
-      (valgrind --leak-check=full \
-          --show-leak-kinds=all -v \
-          bin/verifier\
-          2> verifier-valgrind-stderr.log) ;\
-      sleep 1 ; \
-      pkill -SIGINT -f bin/attester
-
-* AddressSanitizer:
-
-      make clean ; make address-sanitizer=1
-      (bin/attester &); sleep .2 ; bin/verifier ; sleep 1 ; pkill -SIGINT -f bin/attester
-
-  This Make flag is part of the CHARRA `Makefile` and adds the `-fsanitize=address` argument to `CFLAGS` and `LDFLAGS`.
-
-## Run Attester and Verifier on different Devices
-
-The attester and verifier can be used on two different devices.
-To do that, you have to provide an external network for the attester Docker container.
-
-1. Create [macvlan network](https://docs.docker.com/network/macvlan/) for attester Docker container (check your gateway address and replace `x` with the correct number):
-
-       docker network create -d macvlan \
-           --subnet=192.168.x.0/24 \
-           --gateway=192.168.x.1 \
-           -o parent=eth0 pub_net
-
-2. Add `--network` parameter to the `docker run` command in the `docker/run.sh` on the attester device:
-
-       ## run (transient) Docker container
-       /usr/bin/docker run --rm -it \
-           -v "${PWD}/:/home/bob/charra" \
-           --network=pub_net \
-           "${docker_image_fullname}" \
-           "$@"
-
-3. Run the attester Docker container and check the IP address.
-
-4. Put the attester address to the `DST_HOST` in `src/verifier.c` on the verifier device.
-   Rebuild verifier script in the verifier docker container:
-
-       cd charra
-       make -j
-
-5. Go to `charra` directory and run attester binary in the attester docker container:
-
-       cd charra
-       bin/attester
-
-6. Run the verifier binary in the verifier docker container:
-
-       /bin/verifier
-
-If you see "ATTESTATION SUCCESSFUL" you're done. Congratz :-D

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,35 +5,39 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: fraunhofer-sit/charra-dev-env:1.5.1
-    restart: unless-stopped
+      args:
+        user: bob
+        uid: 1000
+        gid: 1000
+    image: fraunhofer-sit/charra-dev-env:1.7.0
     container_name: charra-dev-env
+    restart: unless-stopped
     volumes:
       - ".:/home/bob/charra"
     #ports:
     #  - "127.0.0.1:8080:8080"
     #command: >
     #  /bin/bash
-  charra-attester:
-    build:
-      context: .
-      dockerfile: Dockerfile.app
-    image: fraunhofer-sit/charra:1.5.1
-    restart: unless-stopped
-    container_name: charra-attester
-    ports:
-      - "127.0.0.1:5683:5683"
-    command: >
-      /home/bob/charra/bin/attester
-  charra-verifier:
-    build:
-      context: .
-      dockerfile: Dockerfile.app
-    image: fraunhofer-sit/charra:1.5.1
-    restart: unless-stopped
-    container_name: charra-verifier
+#  charra-attester:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile.app
+#    image: fraunhofer-sit/charra:1.5.1
+#    container_name: charra-attester
+#    restart: unless-stopped
+#    ports:
+#      - "127.0.0.1:5683:5683"
+#    command: >
+#      /home/bob/charra/bin/attester
+#  charra-verifier:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile.app
+#    image: fraunhofer-sit/charra:1.5.1
+#    container_name: charra-verifier
+#    restart: unless-stopped
     #ports:
     #  - "127.0.0.1:5683:5683"
-    command: >
-      /home/bob/charra/bin/verifier
+#    command: >
+#      /home/bob/charra/bin/verifier
 

--- a/docker/dist/usr/local/bin/compile-tss
+++ b/docker/dist/usr/local/bin/compile-tss
@@ -2,7 +2,7 @@
 
 until [ -z "${1}" ]; do
 	gcc -std=c99 -pedantic -Wall -fdata-sections -ffunction-sections \
-		-I/usr/local/include/ "${1}" -L=/usr/local/lib \
+		-I/usr/local/include "${1}" -L=/usr/local/lib \
 		-ltss2-fapi -ltss2-esys -ltss2-sys -ltss2-mu \
 		-ltss2-tcti-device -ltss2-tcti-mssim \
 		-o "${1%.c}"


### PR DESCRIPTION
* Fixed `Makefile` (fixes #65)

* Fixed Docker Compose (fixes #66)

* Externalized building and installation instructions into `INSTALL.md` and the changelog into `CHANGELOG.md`.

* Minor adjustments.