### PR TITLE
Using CoAP message type provided by libcoap instead of custom one.

### DIFF
--- a/src/util/coap_util.c
+++ b/src/util/coap_util.c
@@ -128,12 +128,12 @@ coap_session_t* charra_coap_new_client_session_pki(coap_context_t* coap_context,
 }
 
 coap_pdu_t* charra_coap_new_request(coap_session_t* session,
-        coap_message_t msg_type, coap_request_t method,
+        coap_pdu_type_t pdu_type, coap_pdu_code_t pdu_code,
         coap_optlist_t** options, const uint8_t* data, const size_t data_len) {
     coap_pdu_t* pdu = NULL;
 
     /* create new PDU */
-    if ((pdu = coap_new_pdu(msg_type, method, session)) == NULL) {
+    if ((pdu = coap_new_pdu(pdu_type, pdu_code, session)) == NULL) {
         charra_log_error("[" LOG_NAME "] Cannot create PDU");
         goto error;
     }
@@ -146,15 +146,15 @@ coap_pdu_t* charra_coap_new_request(coap_session_t* session,
 
     /* generate new token */
     static unsigned char _token_data[24]; /* With support for RFC8974 */
-    coap_binary_t the_token = { 0, _token_data };
+    coap_binary_t the_token = {0, _token_data};
 
-    uint8_t token[8];
-    size_t tokenlen;
+    uint8_t token[8] = {0};
+    size_t tokenlen = 0;
 
     /* add token to PDU */
     if (the_token.length > COAP_TOKEN_DEFAULT_MAX) {
         coap_session_new_token(session, &tokenlen, token);
-        /* Update the last part 8 bytes of the large token */
+        /* Update the last 8 bytes of the large token */
         memcpy(&the_token.s[the_token.length - tokenlen], token, tokenlen);
     } else {
         coap_session_new_token(session, &the_token.length, the_token.s);

--- a/src/util/coap_util.h
+++ b/src/util/coap_util.h
@@ -51,20 +51,6 @@ typedef struct coap_token_t {
  */
 typedef uint16_t coap_message_id_t;
 
-/**
- * @brief CoAP message type.
- *
- */
-typedef uint8_t coap_message_t;
-/* confirmable message (requires ACK/RST) */
-#define COAP_MESSAGE_TYPE_CON ((coap_message_t)COAP_MESSAGE_CON)
-/* non-confirmable message (one-shot message) */
-#define COAP_MESSAGE_TYPE_NON ((coap_message_t)COAP_MESSAGE_NON)
-/* used to acknowledge confirmable messages */
-#define COAP_MESSAGE_TYPE_ACK ((coap_message_t)COAP_MESSAGE_ACK)
-/* indicates error in received messages */
-#define COAP_MESSAGE_TYPE_RST ((coap_message_t)COAP_MESSAGE_RST)
-
 /* --- function forward declarations -------------------------------------- */
 
 /**
@@ -144,7 +130,7 @@ coap_session_t* charra_coap_new_client_session_pki(coap_context_t* coap_context,
  *
  * @param session the CoAP session.
  * @param msg_type the CoAP message type.
- * @param method the CoAP request method.
+ * @param pdu_code the CoAP PDU code (request, response, signalling).
  * @param options list of CoAP options.
  * @param data the data to send (this can be larger than the typical size of
  * 1024 bytes for one PDU since internally CoAP block-wise transfers are
@@ -154,7 +140,7 @@ coap_session_t* charra_coap_new_client_session_pki(coap_context_t* coap_context,
  * @return NULL in case of an error.
  */
 coap_pdu_t* charra_coap_new_request(coap_session_t* session,
-        coap_message_t msg_type, coap_request_t method,
+        coap_pdu_type_t pdu_type, coap_pdu_code_t pdu_code,
         coap_optlist_t** options, const uint8_t* data, const size_t data_len);
 
 /**

--- a/src/verifier.c
+++ b/src/verifier.c
@@ -102,9 +102,8 @@ static CHARRA_RC create_attestation_request(
         msg_attestation_request_dto* attestation_request);
 
 static coap_response_t coap_attest_handler(coap_session_t* session,
-                                        const coap_pdu_t* sent,
-                                        const coap_pdu_t* received,
-                                        const coap_mid_t mid);
+        const coap_pdu_t* sent, const coap_pdu_t* received,
+        const coap_mid_t mid);
 
 /* --- static variables --------------------------------------------------- */
 
@@ -371,9 +370,9 @@ int main(int argc, char** argv) {
 
     /* new CoAP request PDU */
     charra_log_info("[" LOG_NAME "] Creating request PDU.");
-    if ((pdu = charra_coap_new_request(coap_session, COAP_MESSAGE_TYPE_CON,
-                 COAP_REQUEST_FETCH, &coap_options, req_buf, req_buf_len)) ==
-            NULL) {
+    if ((pdu = charra_coap_new_request(coap_session, COAP_MESSAGE_CON,
+                 COAP_REQUEST_CODE_FETCH, &coap_options, req_buf,
+                 req_buf_len)) == NULL) {
         charra_log_error("[" LOG_NAME "] Cannot create request PDU.");
         result = CHARRA_RC_ERROR;
         goto cleanup;
@@ -505,8 +504,7 @@ static CHARRA_RC create_attestation_request(
 
 static coap_response_t coap_attest_handler(
         coap_session_t* session CHARRA_UNUSED,
-        const coap_pdu_t* sent CHARRA_UNUSED,
-        const coap_pdu_t* received,
+        const coap_pdu_t* sent CHARRA_UNUSED, const coap_pdu_t* received,
         const coap_mid_t mid CHARRA_UNUSED) {
     int coap_r = 0;
     TSS2_RC tss_r = 0;
@@ -527,8 +525,8 @@ static coap_response_t coap_attest_handler(
     const uint8_t* data = NULL;
     size_t data_offset = 0;
     size_t data_total_len = 0;
-    if ((coap_r = coap_get_data_large(
-                 received, &data_len, &data, &data_offset, &data_total_len)) == 0) {
+    if ((coap_r = coap_get_data_large(received, &data_len, &data, &data_offset,
+                 &data_total_len)) == 0) {
         charra_log_error("[" LOG_NAME "] Could not get CoAP PDU data.");
         attestation_rc = CHARRA_RC_ERROR;
         goto cleanup;


### PR DESCRIPTION
* Removed custom CoAP message type coap_message_t
* Instead using coap_pdu_type_t that is now included in libcoap

Fixes #82.