### PR TITLE
Added verification of TPM2 magic; some code polishing.

### DIFF
--- a/src/attester.c
+++ b/src/attester.c
@@ -290,7 +290,9 @@ static void coap_attest_handler(struct coap_resource_t* resource,
     TSS2_RC tss_r = 0;
     ESYS_TR sig_key_handle = ESYS_TR_NONE;
     TPM2B_PUBLIC* public_key = NULL;
+
     /* --- receive incoming data --- */
+
     charra_log_info(
             "[" LOG_NAME "] Resource '%s': Received message.", "attest");
     coap_show_pdu(LOG_DEBUG, request);
@@ -333,9 +335,11 @@ static void coap_attest_handler(struct coap_resource_t* resource,
     qualifying_data.size = req.nonce_len;
     memcpy(qualifying_data.buffer, req.nonce, req.nonce_len);
 
-    charra_log_info("Received nonce of length %d:", req.nonce_len);
+    charra_log_info("[" LOG_NAME
+                    "] Received qualifying data (nonce) of length %d:",
+            req.nonce_len);
     charra_print_hex(CHARRA_LOG_INFO, req.nonce_len, req.nonce,
-            "                                   0x", "\n", false);
+            "                                              0x", "\n", false);
 
     /* PCR selection */
     TPML_PCR_SELECTION pcr_selection = {0};
@@ -361,25 +365,26 @@ static void coap_attest_handler(struct coap_resource_t* resource,
     }
 
     /* load TPM key */
-    charra_log_info("[" LOG_NAME "] Loading TPM key.");
-    if ((charra_r = charra_load_tpm2_key(esys_ctx, req.sig_key_id_len,
-                 req.sig_key_id, &sig_key_handle, attestation_key_ctx_path)) !=
-            CHARRA_RC_SUCCESS) {
-        charra_log_error("[" LOG_NAME "] Could not load TPM key.");
+    charra_log_info("[" LOG_NAME "] Loading TPM (attestation) key.");
+    if ((charra_r = charra_load_tpm2_key(esys_ctx, &sig_key_handle,
+                 attestation_key_ctx_path)) != CHARRA_RC_SUCCESS) {
+        charra_log_error(
+                "[" LOG_NAME "] Could not load TPM (attestation) key.");
         goto error;
     }
 
-    /* do the TPM quote */
-    charra_log_info("[" LOG_NAME "] Do TPM Quote.");
+    /* perform TPM quote */
+    charra_log_info("[" LOG_NAME "] Perform TPM2 Quote.");
     TPM2B_ATTEST* attest_buf = NULL;
     TPMT_SIGNATURE* signature = NULL;
     if ((tss_r = tpm2_quote(esys_ctx, sig_key_handle, &pcr_selection,
                  &qualifying_data, &attest_buf, &signature)) !=
             TSS2_RC_SUCCESS) {
-        charra_log_error("[" LOG_NAME "] TPM2 quote. %d", tss_r);
+        charra_log_error(
+                "[" LOG_NAME "] TPM2 quote unsuccessful. Error: %d", tss_r);
         goto error;
     } else {
-        charra_log_info("[" LOG_NAME "] TPM Quote successful.");
+        charra_log_info("[" LOG_NAME "] TPM2 Quote successful.");
     }
 
     /* --- send response data --- */

--- a/src/core/charra_key_mgr.c
+++ b/src/core/charra_key_mgr.c
@@ -30,18 +30,13 @@
 #include "../common/charra_log.h"
 #include "../util/tpm2_util.h"
 
-CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
-        const uint8_t* key, ESYS_TR* key_handle, const char* path) {
+CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* const ctx,
+        ESYS_TR* const key_handle, const char* const path) {
     TSS2_RC r = TSS2_RC_SUCCESS;
-    if (memcmp(key, "PK.RSA.default", key_len) == 0) {
-        charra_log_info("Loading key \"PK.RSA.default\".");
-        r = tpm2_load_tpm_context_from_path(ctx, key_handle, path);
-        if (r != TSS2_RC_SUCCESS) {
-            charra_log_error("Loading of key \"PK.RSA.default\" failed.");
-            return CHARRA_RC_ERROR;
-        }
-    } else {
-        charra_log_error("TPM key not found.");
+
+    /* load TPM2 attestation key */
+    if ((r = tpm2_load_tpm_context_from_path(ctx, key_handle, path)) !=
+            TSS2_RC_SUCCESS) {
         return CHARRA_RC_ERROR;
     }
 
@@ -60,10 +55,9 @@ CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
         charra_log_error("Invalid pointer for external public key.");
         return CHARRA_RC_ERROR;
     }
-    charra_log_info("Loading TPM key from file.");
-    if (tpm2_load_external_public_key_from_path(path, external_public_key)) {
-        charra_log_info("Loaded external public key.");
-    } else {
+
+    // charra_log_info("Loading TPM key from file.");
+    if (!tpm2_load_external_public_key_from_path(path, external_public_key)) {
         charra_log_error("Loading external public key from file failed.");
         return CHARRA_RC_ERROR;
     }

--- a/src/core/charra_key_mgr.h
+++ b/src/core/charra_key_mgr.h
@@ -28,8 +28,8 @@
 
 #include "../common/charra_error.h"
 
-CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* ctx, const uint32_t key_len,
-        const uint8_t* key, ESYS_TR* key_handle, const char* path);
+CHARRA_RC charra_load_tpm2_key(ESYS_CONTEXT* const ctx,
+        ESYS_TR* const key_handle, const char* const path);
 
 CHARRA_RC charra_load_external_public_key(ESYS_CONTEXT* ctx,
         TPM2B_PUBLIC* external_public_key, ESYS_TR* key_handle,

--- a/src/util/charra_util.c
+++ b/src/util/charra_util.c
@@ -49,7 +49,7 @@ static const unsigned char mbedtls_personalization[] =
 static const unsigned char mbedtls_personalization_len =
         sizeof(mbedtls_personalization);
 
-CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* random_bytes) {
+CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* const random_bytes) {
     CHARRA_RC charra_r = CHARRA_RC_SUCCESS;
     /* initialize contexts */
     mbedtls_entropy_context entropy = {0};
@@ -83,7 +83,7 @@ error:
 }
 
 CHARRA_RC charra_random_bytes_from_tpm(
-        const uint32_t len, uint8_t* random_bytes) {
+        const uint32_t len, uint8_t* const random_bytes) {
     assert(len <= sizeof(TPMU_HA));
 
     TSS2_RC tss2_rc = 0;
@@ -134,10 +134,10 @@ error:
     return charra_rc;
 }
 
-TSS2_RC charra_verify_tpm2_quote_signature_with_tpm(ESYS_CONTEXT* ctx,
+TSS2_RC charra_verify_tpm2_quote_signature_with_tpm(ESYS_CONTEXT* const ctx,
         const ESYS_TR sig_key_handle, const TPM2_ALG_ID hash_algo_id,
-        const TPM2B_ATTEST* attest_buf, TPMT_SIGNATURE* signature,
-        TPMT_TK_VERIFIED** validation) {
+        const TPM2B_ATTEST* const attest_buf, TPMT_SIGNATURE* const signature,
+        TPMT_TK_VERIFIED** const validation) {
     TSS2_RC tss2_r = TSS2_RC_SUCCESS;
     char* error_msg = NULL;
 
@@ -181,8 +181,8 @@ error:
     return tss2_r;
 }
 
-CHARRA_RC charra_unmarshal_tpm2_quote(size_t attest_buf_len,
-        const uint8_t* attest_buf, TPMS_ATTEST* attest_struct) {
+CHARRA_RC charra_unmarshal_tpm2_quote(const size_t attest_buf_len,
+        const uint8_t* const attest_buf, TPMS_ATTEST* const attest_struct) {
     CHARRA_RC charra_rc = CHARRA_RC_SUCCESS;
     TSS2_RC tss2_rc = TSS2_RC_SUCCESS;
     char* error_msg = NULL;
@@ -222,7 +222,18 @@ error:
     return charra_rc;
 }
 
-bool charra_verify_tpm2_quote_qualifying_data(uint16_t qualifying_data_len,
+bool charra_verify_tpm2_magic(const TPMS_ATTEST* const attest_struct) {
+    /* verify input parameters */
+    if (attest_struct == NULL) {
+        return false;
+    }
+
+    /* check if TPM2 magic matches */
+    return (TPM2_GENERATED_VALUE == attest_struct->magic);
+}
+
+bool charra_verify_tpm2_quote_qualifying_data(
+        const uint16_t qualifying_data_len,
         const uint8_t* const qualifying_data,
         const TPMS_ATTEST* const attest_struct) {
     /* verify input parameters */
@@ -260,6 +271,7 @@ bool charra_verify_tpm2_quote_pcr_composite_digest(
         const TPMS_ATTEST* const attest_struct,
         const uint8_t* const pcr_composite_digest,
         const uint16_t pcr_composite_digest_len) {
+    // TODO(any): to be used
     /* extract PCR digest from attestation structure */
     TPMS_QUOTE_INFO quote_info = attest_struct->attested.quote;
     const uint8_t* const pcr_digest = quote_info.pcrDigest.buffer;

--- a/src/util/charra_util.h
+++ b/src/util/charra_util.h
@@ -37,7 +37,7 @@
  * @return CHARRA_RC_SUCCESS on success.
  * @return CHARRA_RC_ERROR on error.
  */
-CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* random_bytes);
+CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* const random_bytes);
 
 /**
  * @brief Retrieve random bytes from a TPM.
@@ -48,35 +48,74 @@ CHARRA_RC charra_random_bytes(const uint32_t len, uint8_t* random_bytes);
  * @return CHARRA_RC_ERROR on error.
  */
 CHARRA_RC charra_random_bytes_from_tpm(
-        const uint32_t len, uint8_t* random_bytes);
+        const uint32_t len, uint8_t* const random_bytes);
 
 /**
  * @brief Verifies a TPM 2.0 quote using the TPM.
  *
- * @param ctx[in,out] The ESAPI context.
- * @param sig_key_handle[in] The TPM2 handle of the signature key.
- * @param attest[in] The attestation data structure.
- * @param signature[in] The TPM2 signature over \a attest->attestationData.
- * @param validation[out] The validation data that holds the verification
+ * @param[inout] ctx The ESAPI context.
+ * @param[in] sig_key_handle[in] The TPM2 handle of the signature key.
+ * @param[in] attest The attestation data structure.
+ * @param[in] signature The TPM2 signature over \a attest->attestationData.
+ * @param[out] validation The validation data that holds the verification
  * result.
  * @return TSS2_RC The TSS return code.
  */
-CHARRA_RC charra_verify_tpm2_quote_signature_with_tpm(ESYS_CONTEXT* ctx,
+CHARRA_RC charra_verify_tpm2_quote_signature_with_tpm(ESYS_CONTEXT* const ctx,
         const ESYS_TR sig_key_handle, const TPM2_ALG_ID hash_algo_id,
-        const TPM2B_ATTEST* attest_buf, TPMT_SIGNATURE* signature,
-        TPMT_TK_VERIFIED** validation);
+        const TPM2B_ATTEST* const attest_buf, TPMT_SIGNATURE* const signature,
+        TPMT_TK_VERIFIED** const validation);
 
-CHARRA_RC charra_unmarshal_tpm2_quote(size_t attest_buf_len,
-        const uint8_t* attest_buf, TPMS_ATTEST* attest_struct);
+CHARRA_RC charra_unmarshal_tpm2_quote(const size_t attest_buf_len,
+        const uint8_t* const attest_buf, TPMS_ATTEST* const attest_struct);
 
-bool charra_verify_tpm2_quote_qualifying_data(uint16_t qualifying_data_len,
+/**
+ * @brief Verifies whether the TPM2 magic matches the expected one (must always
+ * be TPM_GENERATED_VALUE to indicate that this structure was created by a TPM).
+ *
+ * @param[in] attest_struct The TPM2 attestation structure (unmarshaled version,
+ * i.e., native endianness).
+ * @return true if the magic is valid.
+ * @return false if the magic is invalid.
+ */
+bool charra_verify_tpm2_magic(const TPMS_ATTEST* const attest_struct);
+
+/**
+ * @brief Verifies whether the qualifying data (nonce) matches the one in the
+ * TPM2 attestation structure.
+ *
+ * @param[in] qualifying_data_len The length of the qualifying data (nonce).
+ * @param[in] qualifying_data The qualifying data (nonce).
+ * @param[in] attest_struct The TPM2 attestation structure (unmarshaled version,
+ * i.e., native endianness).
+ * @return true if the qualifying data (nonce) matches the one in \p
+ * attest_struct.
+ * @return false if the qualifying data (nonce) does not match the one in \p
+ * attest_struct.
+ */
+bool charra_verify_tpm2_quote_qualifying_data(
+        const uint16_t qualifying_data_len,
         const uint8_t* const qualifying_data,
         const TPMS_ATTEST* const attest_struct);
 
-bool charra_verify_tpm2_quote_pcrs(TPM2_ALG_ID hash_algo_id,
+// TODO(any): to be implemented
+bool charra_verify_tpm2_quote_pcrs(const TPM2_ALG_ID hash_algo_id,
         const uint8_t* const qualifying_data,
         const TPMS_ATTEST* const attest_struct);
 
+/**
+ * @brief Verifies whether the PCR composite (hash digest) matches the one in
+ * the TPM2 attestation structure.
+ *
+ * @param[in] attest_struct The TPM2 attestation structure (unmarshaled version,
+ * i.e., native endianness).
+ * @param[in] pcr_composite The PCR composite (hash digest) to which to compare.
+ * @param[in] pcr_composite_len The PCR composite (hash digest) length.
+ * @return true if the PCR composite (hash digest) matches the one in \p
+ * attest_struct.
+ * @return false if the PCR composite (hash digest) does not match the one in \p
+ * attest_struct.
+ */
 bool charra_verify_tpm2_quote_pcr_composite_digest(
         const TPMS_ATTEST* const attest_struct,
         const uint8_t* const pcr_composite, const uint16_t pcr_composite_len);


### PR DESCRIPTION
Fixes #90

* Added functionality to verifies whether the TPM2 magic matches the expected one (must always be `TPM_GENERATED_VALUE` to indicate that the attestation structure was created by a TPM).
* Some code polishing, including console output.